### PR TITLE
task system v2 — reviewer + goal dispatcher

### DIFF
--- a/api/spec/domain/goals/paths.yaml
+++ b/api/spec/domain/goals/paths.yaml
@@ -1,0 +1,263 @@
+paths:
+  /api/goals:
+    get:
+      tags: [goals]
+      summary: List goals in the resolved org
+      operationId: listGoals
+      parameters:
+        - {
+            name: limit,
+            in: query,
+            required: false,
+            schema: { type: integer, format: int64 },
+          }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                { $ref: "../../components.yaml#/components/schemas/GoalList" }
+        "401":
+          { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+    post:
+      tags: [goals]
+      summary: Create a goal
+      operationId: createGoal
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              {
+                $ref: "../../components.yaml#/components/schemas/CreateGoalRequest",
+              }
+      responses:
+        "201":
+          description: created
+          content:
+            application/json:
+              schema:
+                { $ref: "../../components.yaml#/components/schemas/Goal" }
+        "400":
+          { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401":
+          { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  /api/goals/{goalID}:
+    parameters:
+      - { name: goalID, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [goals]
+      summary: Get a goal
+      operationId: getGoal
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                { $ref: "../../components.yaml#/components/schemas/Goal" }
+        "401":
+          { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
+  /api/goals/{goalID}/activate:
+    parameters:
+      - { name: goalID, in: path, required: true, schema: { type: string } }
+    post:
+      tags: [goals]
+      summary: Activate a goal (draft → running, promotes draft children to ready)
+      operationId: activateGoal
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                { $ref: "../../components.yaml#/components/schemas/Goal" }
+        "401":
+          { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+        "409":
+          { $ref: "../../components.yaml#/components/responses/Conflict" }
+
+  /api/goals/{goalID}/cancel:
+    parameters:
+      - { name: goalID, in: path, required: true, schema: { type: string } }
+    post:
+      tags: [goals]
+      summary: Cancel a goal (cascades to non-terminal children)
+      operationId: cancelGoal
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              {
+                $ref: "../../components.yaml#/components/schemas/CancelGoalRequest",
+              }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                { $ref: "../../components.yaml#/components/schemas/Goal" }
+        "401":
+          { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+        "409":
+          { $ref: "../../components.yaml#/components/responses/Conflict" }
+
+  /api/goals/{goalID}/tasks:
+    parameters:
+      - { name: goalID, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [goals]
+      summary: List tasks owned by a goal
+      operationId: listGoalTasks
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                { $ref: "../../components.yaml#/components/schemas/TaskList" }
+        "401":
+          { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
+  /api/goals/{goalID}/reviews:
+    parameters:
+      - { name: goalID, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [goals]
+      summary: List reviews for a goal
+      operationId: listGoalReviews
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                { $ref: "../../components.yaml#/components/schemas/ReviewList" }
+        "401":
+          { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
+  /api/goals/{goalID}/reviews/{reviewID}/approve:
+    parameters:
+      - { name: goalID, in: path, required: true, schema: { type: string } }
+      - { name: reviewID, in: path, required: true, schema: { type: string } }
+    post:
+      tags: [goals]
+      summary: Approve a goal review
+      operationId: approveGoalReview
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              {
+                $ref: "../../components.yaml#/components/schemas/ReviewDecisionRequest",
+              }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                { $ref: "../../components.yaml#/components/schemas/Review" }
+        "401":
+          { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+        "409":
+          { $ref: "../../components.yaml#/components/responses/Conflict" }
+
+  /api/goals/{goalID}/reviews/{reviewID}/reject:
+    parameters:
+      - { name: goalID, in: path, required: true, schema: { type: string } }
+      - { name: reviewID, in: path, required: true, schema: { type: string } }
+    post:
+      tags: [goals]
+      summary: Reject a goal review
+      operationId: rejectGoalReview
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              {
+                $ref: "../../components.yaml#/components/schemas/ReviewDecisionRequest",
+              }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                { $ref: "../../components.yaml#/components/schemas/Review" }
+        "401":
+          { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+        "409":
+          { $ref: "../../components.yaml#/components/responses/Conflict" }
+
+  /api/goals/{goalID}/reviews/{reviewID}/request-changes:
+    parameters:
+      - { name: goalID, in: path, required: true, schema: { type: string } }
+      - { name: reviewID, in: path, required: true, schema: { type: string } }
+    post:
+      tags: [goals]
+      summary: Request changes on a goal review (collapses to failed; documented gap)
+      operationId: requestChangesGoalReview
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              {
+                $ref: "../../components.yaml#/components/schemas/ReviewDecisionRequest",
+              }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                { $ref: "../../components.yaml#/components/schemas/Review" }
+        "401":
+          { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+        "409":
+          { $ref: "../../components.yaml#/components/responses/Conflict" }
+
+  /api/goals/{goalID}/reviews/{reviewID}/escalate:
+    parameters:
+      - { name: goalID, in: path, required: true, schema: { type: string } }
+      - { name: reviewID, in: path, required: true, schema: { type: string } }
+    post:
+      tags: [goals]
+      summary: Escalate an agent goal review to human
+      operationId: escalateGoalReview
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              {
+                $ref: "../../components.yaml#/components/schemas/EscalateReviewRequest",
+              }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                { $ref: "../../components.yaml#/components/schemas/Review" }
+        "401":
+          { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+        "409":
+          { $ref: "../../components.yaml#/components/responses/Conflict" }

--- a/api/spec/domain/goals/schemas.yaml
+++ b/api/spec/domain/goals/schemas.yaml
@@ -1,0 +1,88 @@
+openapi: 3.0.3
+info:
+  title: Agent Goals Components
+  version: "1"
+paths: {}
+components:
+  schemas:
+    Goal:
+      type: object
+      required:
+        [
+          id,
+          org_id,
+          user_id,
+          title,
+          status,
+          priority,
+          review_policy,
+          created_at,
+          updated_at,
+        ]
+      properties:
+        id: { type: string }
+        org_id: { type: string }
+        user_id: { type: string }
+        agent_id: { type: string }
+        title: { type: string }
+        description: { type: string }
+        status:
+          type: string
+          enum:
+            [
+              draft,
+              planning,
+              running,
+              blocked,
+              reviewing,
+              done,
+              failed,
+              cancelled,
+            ]
+        priority:
+          type: string
+          enum: [routine, urgent]
+        review_policy:
+          type: string
+          enum: [none, auto, agent, human]
+        active_review_id: { type: string }
+        context:
+          type: object
+          additionalProperties: {}
+        output:
+          type: object
+          additionalProperties: {}
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+        completed_at: { type: string, format: date-time }
+        cancelled_at: { type: string, format: date-time }
+
+    GoalList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items: { $ref: "#/components/schemas/Goal" }
+
+    CreateGoalRequest:
+      type: object
+      required: [title]
+      properties:
+        title: { type: string }
+        description: { type: string }
+        priority:
+          type: string
+          enum: [routine, urgent]
+        agent_id: { type: string }
+        review_policy:
+          type: string
+          enum: [none, auto, agent, human]
+        context:
+          type: object
+          additionalProperties: {}
+
+    CancelGoalRequest:
+      type: object
+      properties:
+        reason: { type: string }

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -289,6 +289,27 @@ paths:
     $ref: "./domain/tasks/paths.yaml#/paths/~1api~1tasks~1{taskID}~1reviews~1{reviewID}~1request-changes"
   /api/tasks/{taskID}/reviews/{reviewID}/escalate:
     $ref: "./domain/tasks/paths.yaml#/paths/~1api~1tasks~1{taskID}~1reviews~1{reviewID}~1escalate"
+  # ── Goals ──────────────────────────────────────────────────────────────────
+  /api/goals:
+    $ref: "./domain/goals/paths.yaml#/paths/~1api~1goals"
+  /api/goals/{goalID}:
+    $ref: "./domain/goals/paths.yaml#/paths/~1api~1goals~1{goalID}"
+  /api/goals/{goalID}/activate:
+    $ref: "./domain/goals/paths.yaml#/paths/~1api~1goals~1{goalID}~1activate"
+  /api/goals/{goalID}/cancel:
+    $ref: "./domain/goals/paths.yaml#/paths/~1api~1goals~1{goalID}~1cancel"
+  /api/goals/{goalID}/tasks:
+    $ref: "./domain/goals/paths.yaml#/paths/~1api~1goals~1{goalID}~1tasks"
+  /api/goals/{goalID}/reviews:
+    $ref: "./domain/goals/paths.yaml#/paths/~1api~1goals~1{goalID}~1reviews"
+  /api/goals/{goalID}/reviews/{reviewID}/approve:
+    $ref: "./domain/goals/paths.yaml#/paths/~1api~1goals~1{goalID}~1reviews~1{reviewID}~1approve"
+  /api/goals/{goalID}/reviews/{reviewID}/reject:
+    $ref: "./domain/goals/paths.yaml#/paths/~1api~1goals~1{goalID}~1reviews~1{reviewID}~1reject"
+  /api/goals/{goalID}/reviews/{reviewID}/request-changes:
+    $ref: "./domain/goals/paths.yaml#/paths/~1api~1goals~1{goalID}~1reviews~1{reviewID}~1request-changes"
+  /api/goals/{goalID}/reviews/{reviewID}/escalate:
+    $ref: "./domain/goals/paths.yaml#/paths/~1api~1goals~1{goalID}~1reviews~1{reviewID}~1escalate"
   # ── Plugins ────────────────────────────────────────────────────────────────
   /api/plugins:
     $ref: "./domain/plugins/paths.yaml#/paths/~1api~1plugins"
@@ -588,4 +609,12 @@ components:
     }
     EscalateReviewRequest: {
       $ref: "./components.yaml#/components/schemas/EscalateReviewRequest",
+    }
+    Goal: { $ref: "./components.yaml#/components/schemas/Goal" }
+    GoalList: { $ref: "./components.yaml#/components/schemas/GoalList" }
+    CreateGoalRequest: {
+      $ref: "./components.yaml#/components/schemas/CreateGoalRequest",
+    }
+    CancelGoalRequest: {
+      $ref: "./components.yaml#/components/schemas/CancelGoalRequest",
     }

--- a/internal/db/queries/agent_review.sql
+++ b/internal/db/queries/agent_review.sql
@@ -20,6 +20,22 @@ LIMIT 1;
 -- name: ListAgentReviewsByTask :many
 SELECT * FROM agent_review WHERE task_id = ? ORDER BY created_at DESC;
 
+-- name: ListAgentReviewsByGoal :many
+SELECT * FROM agent_review WHERE goal_id = ? ORDER BY created_at DESC;
+
+-- Reviews awaiting agent dispatch: open, reviewer_type='agent', reviewer_run_id unset.
+-- name: ListOpenAgentReviewsForDispatch :many
+SELECT * FROM agent_review
+WHERE status IN ('requested','in_progress')
+  AND reviewer_type = 'agent'
+  AND reviewer_run_id IS NULL
+ORDER BY created_at ASC
+LIMIT ?;
+
+-- name: SetAgentReviewReviewerRun :execrows
+UPDATE agent_review SET reviewer_run_id = ?, status = 'in_progress', updated_at = ?
+WHERE id = ? AND reviewer_run_id IS NULL;
+
 -- name: SetAgentReviewDecision :execrows
 UPDATE agent_review
 SET status = ?, summary = ?, feedback = ?, resolved_at = ?, updated_at = ?

--- a/internal/db/queries/agent_task_event.sql
+++ b/internal/db/queries/agent_task_event.sql
@@ -2,14 +2,17 @@
 
 -- name: InsertAgentTaskEvent :one
 INSERT INTO agent_task_event (
-    id, task_id, run_id, blocker_id, review_id, event_type, from_status, to_status,
+    id, task_id, goal_id, run_id, blocker_id, review_id, event_type, from_status, to_status,
     actor_type, actor_id, detail, created_at
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: ListAgentTaskEvents :many
 SELECT * FROM agent_task_event WHERE task_id = ? ORDER BY created_at ASC;
+
+-- name: ListAgentTaskEventsByGoal :many
+SELECT * FROM agent_task_event WHERE goal_id = ? ORDER BY created_at ASC;
 
 -- name: ListAgentTaskEventsByRun :many
 SELECT * FROM agent_task_event WHERE run_id = ? ORDER BY created_at ASC;

--- a/internal/db/queries/agent_task_run.sql
+++ b/internal/db/queries/agent_task_run.sql
@@ -2,11 +2,11 @@
 
 -- name: CreateAgentTaskRun :one
 INSERT INTO agent_task_run (
-    id, task_id, org_id, user_id, agent_id, executor_agent_id,
+    id, task_id, goal_id, org_id, user_id, agent_id, executor_agent_id,
     kind, attempt_no, status, session_id, input, lease_expires_at, worker_id,
     started_at, created_at, updated_at
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: GetAgentTaskRun :one
@@ -25,6 +25,17 @@ LIMIT 1;
 SELECT COALESCE(MAX(attempt_no), 0) + 1 AS next_attempt
 FROM agent_task_run
 WHERE task_id = ? AND kind = ?;
+
+-- name: NextAttemptNoForGoal :one
+SELECT COALESCE(MAX(attempt_no), 0) + 1 AS next_attempt
+FROM agent_task_run
+WHERE goal_id = ? AND kind = ?;
+
+-- name: LatestAgentTaskRunForGoal :one
+SELECT * FROM agent_task_run
+WHERE goal_id = ? AND kind = ?
+ORDER BY attempt_no DESC
+LIMIT 1;
 
 -- name: HeartbeatAgentTaskRun :execrows
 UPDATE agent_task_run

--- a/internal/server/goals.go
+++ b/internal/server/goals.go
@@ -1,0 +1,344 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	apiserver "github.com/CherryHQ/stella/api/server"
+	apitypes "github.com/CherryHQ/stella/api/types"
+	"github.com/CherryHQ/stella/internal/tasks"
+	"github.com/CherryHQ/stella/pkg/db/sqlc"
+)
+
+// loadGoalInOrg fetches a goal by id and enforces the org boundary. Returns
+// false (after writing 404) on miss / mismatch.
+func (s *Server) loadGoalInOrg(ctx context.Context, w http.ResponseWriter, goalID, orgID string) (sqlc.AgentGoal, bool) {
+	g, err := s.tasksSvc.Facade.GetGoal(ctx, goalID)
+	if err != nil {
+		if errors.Is(err, tasks.ErrGoalNotFound) {
+			writeError(w, http.StatusNotFound, "not_found")
+			return sqlc.AgentGoal{}, false
+		}
+		taskError(w, err)
+		return sqlc.AgentGoal{}, false
+	}
+	if g.OrgID != orgID {
+		writeError(w, http.StatusNotFound, "not_found")
+		return sqlc.AgentGoal{}, false
+	}
+	return g, true
+}
+
+// ListGoals returns the resolved org's goals.
+func (s *Server) ListGoals(w http.ResponseWriter, r *http.Request, params apiserver.ListGoalsParams) {
+	if !s.tasksReady() {
+		writeError(w, http.StatusServiceUnavailable, "task_service_unavailable")
+		return
+	}
+	org := requireOrg(w, r)
+	if org == "" {
+		return
+	}
+	var limit int64 = 50
+	if params.Limit != nil && *params.Limit > 0 {
+		limit = *params.Limit
+	}
+	rows, err := s.tasksSvc.Facade.ListGoalsByOrg(r.Context(), org, limit)
+	if err != nil {
+		taskError(w, err)
+		return
+	}
+	out := make([]apitypes.Goal, 0, len(rows))
+	for _, g := range rows {
+		out = append(out, goalToAPI(g))
+	}
+	writeData(w, http.StatusOK, apitypes.GoalList{Items: out})
+}
+
+func (s *Server) CreateGoal(w http.ResponseWriter, r *http.Request) {
+	if !s.tasksReady() {
+		writeError(w, http.StatusServiceUnavailable, "task_service_unavailable")
+		return
+	}
+	org := requireOrg(w, r)
+	if org == "" {
+		return
+	}
+	info := UserFromContext(r.Context())
+	if info == nil || info.UserID == "" {
+		writeError(w, http.StatusUnauthorized, "missing_user")
+		return
+	}
+	var req apitypes.CreateGoalRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_body")
+		return
+	}
+	if req.Title == "" {
+		writeError(w, http.StatusBadRequest, "title_required")
+		return
+	}
+	in := tasks.CreateGoalInput{
+		OrgID:       org,
+		UserID:      info.UserID,
+		Title:       req.Title,
+		Description: strPtr(req.Description),
+		AgentID:     strPtr(req.AgentId),
+		Context:     marshalContext(req.Context),
+	}
+	if req.Priority != nil {
+		in.Priority = string(*req.Priority)
+	}
+	if req.ReviewPolicy != nil {
+		in.ReviewPolicy = string(*req.ReviewPolicy)
+	}
+	g, err := s.tasksSvc.Facade.CreateGoal(r.Context(), in)
+	if err != nil {
+		taskError(w, err)
+		return
+	}
+	writeData(w, http.StatusCreated, goalToAPI(g))
+}
+
+func (s *Server) GetGoal(w http.ResponseWriter, r *http.Request, goalID string) {
+	if !s.tasksReady() {
+		writeError(w, http.StatusServiceUnavailable, "task_service_unavailable")
+		return
+	}
+	org := requireOrg(w, r)
+	if org == "" {
+		return
+	}
+	g, ok := s.loadGoalInOrg(r.Context(), w, goalID, org)
+	if !ok {
+		return
+	}
+	writeData(w, http.StatusOK, goalToAPI(g))
+}
+
+func (s *Server) ActivateGoal(w http.ResponseWriter, r *http.Request, goalID string) {
+	if !s.tasksReady() {
+		writeError(w, http.StatusServiceUnavailable, "task_service_unavailable")
+		return
+	}
+	org := requireOrg(w, r)
+	if org == "" {
+		return
+	}
+	g, ok := s.loadGoalInOrg(r.Context(), w, goalID, org)
+	if !ok {
+		return
+	}
+	if err := s.tasksSvc.Facade.ActivateGoal(r.Context(), g.ID, authActor(r)); err != nil {
+		taskError(w, err)
+		return
+	}
+	fresh, err := s.tasksSvc.Facade.GetGoal(r.Context(), g.ID)
+	if err != nil {
+		taskError(w, err)
+		return
+	}
+	writeData(w, http.StatusOK, goalToAPI(fresh))
+}
+
+func (s *Server) CancelGoal(w http.ResponseWriter, r *http.Request, goalID string) {
+	if !s.tasksReady() {
+		writeError(w, http.StatusServiceUnavailable, "task_service_unavailable")
+		return
+	}
+	org := requireOrg(w, r)
+	if org == "" {
+		return
+	}
+	g, ok := s.loadGoalInOrg(r.Context(), w, goalID, org)
+	if !ok {
+		return
+	}
+	var req apitypes.CancelGoalRequest
+	_ = decodeJSON(r, &req)
+	if err := s.tasksSvc.Facade.CancelGoal(r.Context(), g.ID, strPtr(req.Reason), authActor(r)); err != nil {
+		taskError(w, err)
+		return
+	}
+	fresh, err := s.tasksSvc.Facade.GetGoal(r.Context(), g.ID)
+	if err != nil {
+		taskError(w, err)
+		return
+	}
+	writeData(w, http.StatusOK, goalToAPI(fresh))
+}
+
+func (s *Server) ListGoalTasks(w http.ResponseWriter, r *http.Request, goalID string) {
+	if !s.tasksReady() {
+		writeError(w, http.StatusServiceUnavailable, "task_service_unavailable")
+		return
+	}
+	org := requireOrg(w, r)
+	if org == "" {
+		return
+	}
+	g, ok := s.loadGoalInOrg(r.Context(), w, goalID, org)
+	if !ok {
+		return
+	}
+	rows, err := s.tasksSvc.Facade.ListGoalTasks(r.Context(), g.ID)
+	if err != nil {
+		taskError(w, err)
+		return
+	}
+	out := make([]apitypes.Task, 0, len(rows))
+	for _, t := range rows {
+		out = append(out, taskToAPI(t))
+	}
+	writeData(w, http.StatusOK, apitypes.TaskList{Items: out})
+}
+
+func (s *Server) ListGoalReviews(w http.ResponseWriter, r *http.Request, goalID string) {
+	if !s.tasksReady() {
+		writeError(w, http.StatusServiceUnavailable, "task_service_unavailable")
+		return
+	}
+	org := requireOrg(w, r)
+	if org == "" {
+		return
+	}
+	g, ok := s.loadGoalInOrg(r.Context(), w, goalID, org)
+	if !ok {
+		return
+	}
+	rows, err := s.tasksSvc.Facade.ListGoalReviews(r.Context(), g.ID)
+	if err != nil {
+		taskError(w, err)
+		return
+	}
+	out := make([]apitypes.Review, 0, len(rows))
+	for _, rev := range rows {
+		out = append(out, reviewToAPI(rev))
+	}
+	writeData(w, http.StatusOK, apitypes.ReviewList{Items: out})
+}
+
+func (s *Server) ApproveGoalReview(w http.ResponseWriter, r *http.Request, goalID string, reviewID string) {
+	s.decideGoalReview(w, r, goalID, reviewID, "approve")
+}
+
+func (s *Server) RejectGoalReview(w http.ResponseWriter, r *http.Request, goalID string, reviewID string) {
+	s.decideGoalReview(w, r, goalID, reviewID, "reject")
+}
+
+func (s *Server) RequestChangesGoalReview(w http.ResponseWriter, r *http.Request, goalID string, reviewID string) {
+	s.decideGoalReview(w, r, goalID, reviewID, "request_changes")
+}
+
+func (s *Server) EscalateGoalReview(w http.ResponseWriter, r *http.Request, goalID string, reviewID string) {
+	if !s.tasksReady() {
+		writeError(w, http.StatusServiceUnavailable, "task_service_unavailable")
+		return
+	}
+	org := requireOrg(w, r)
+	if org == "" {
+		return
+	}
+	g, ok := s.loadGoalInOrg(r.Context(), w, goalID, org)
+	if !ok {
+		return
+	}
+	rev, err := s.tasksSvc.Facade.GetReview(r.Context(), reviewID)
+	if err != nil || !rev.GoalID.Valid || rev.GoalID.String != g.ID {
+		writeError(w, http.StatusNotFound, "not_found")
+		return
+	}
+	var req apitypes.EscalateReviewRequest
+	_ = decodeJSON(r, &req)
+	if err := s.tasksSvc.Facade.EscalateReview(r.Context(), reviewID, strPtr(req.Reason), authActor(r)); err != nil {
+		taskError(w, err)
+		return
+	}
+	fresh, err := s.tasksSvc.Facade.GetReview(r.Context(), reviewID)
+	if err != nil {
+		writeData(w, http.StatusOK, reviewToAPI(rev))
+		return
+	}
+	writeData(w, http.StatusOK, reviewToAPI(fresh))
+}
+
+func (s *Server) decideGoalReview(w http.ResponseWriter, r *http.Request, goalID, reviewID, kind string) {
+	if !s.tasksReady() {
+		writeError(w, http.StatusServiceUnavailable, "task_service_unavailable")
+		return
+	}
+	org := requireOrg(w, r)
+	if org == "" {
+		return
+	}
+	g, ok := s.loadGoalInOrg(r.Context(), w, goalID, org)
+	if !ok {
+		return
+	}
+	rev, err := s.tasksSvc.Facade.GetReview(r.Context(), reviewID)
+	if err != nil || !rev.GoalID.Valid || rev.GoalID.String != g.ID {
+		writeError(w, http.StatusNotFound, "not_found")
+		return
+	}
+	var req apitypes.ReviewDecisionRequest
+	_ = decodeJSON(r, &req)
+	actor := authActor(r)
+	switch kind {
+	case "approve":
+		err = s.tasksSvc.Facade.ApproveReview(r.Context(), reviewID, strPtr(req.Summary), actor)
+	case "reject":
+		err = s.tasksSvc.Facade.RejectReview(r.Context(), reviewID, strPtr(req.Summary), strPtr(req.Feedback), actor)
+	case "request_changes":
+		err = s.tasksSvc.Facade.RequestChanges(r.Context(), reviewID, strPtr(req.Summary), strPtr(req.Feedback), actor)
+	}
+	if err != nil {
+		taskError(w, err)
+		return
+	}
+	fresh, gerr := s.tasksSvc.Facade.GetReview(r.Context(), reviewID)
+	if gerr != nil {
+		writeData(w, http.StatusOK, reviewToAPI(rev))
+		return
+	}
+	writeData(w, http.StatusOK, reviewToAPI(fresh))
+}
+
+// goalToAPI converts a sqlc.AgentGoal to its API shape.
+func goalToAPI(g sqlc.AgentGoal) apitypes.Goal {
+	out := apitypes.Goal{
+		Id:           g.ID,
+		OrgId:        g.OrgID,
+		UserId:       g.UserID,
+		Title:        g.Title,
+		Description:  optStr(g.Description),
+		Status:       apitypes.GoalStatus(g.Status),
+		Priority:     apitypes.GoalPriority(g.Priority),
+		ReviewPolicy: apitypes.GoalReviewPolicy(g.ReviewPolicy),
+		CreatedAt:    parseTS(g.CreatedAt),
+		UpdatedAt:    parseTS(g.UpdatedAt),
+	}
+	if g.AgentID.Valid {
+		v := g.AgentID.String
+		out.AgentId = &v
+	}
+	if g.ActiveReviewID.Valid {
+		v := g.ActiveReviewID.String
+		out.ActiveReviewId = &v
+	}
+	if g.CompletedAt.Valid {
+		v := parseTS(g.CompletedAt.String)
+		out.CompletedAt = &v
+	}
+	if g.CancelledAt.Valid {
+		v := parseTS(g.CancelledAt.String)
+		out.CancelledAt = &v
+	}
+	if m := jsonObject(g.Context); m != nil {
+		out.Context = m
+	}
+	if m := jsonObject(g.Output); m != nil {
+		out.Output = m
+	}
+	return out
+}

--- a/internal/server/tasks_test.go
+++ b/internal/server/tasks_test.go
@@ -179,3 +179,79 @@ func TestTasks_EventsListReturnsActivateEvent(t *testing.T) {
 		t.Fatalf("expected at least one event, got none")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Goal HTTP tests
+// ---------------------------------------------------------------------------
+
+func TestGoals_CreateGetRoundTrip(t *testing.T) {
+	env := setupAdmin(t)
+	withTasks(t, env)
+
+	body := apitypes.CreateGoalRequest{Title: "ship it"}
+	rr := doRequest(t, env, http.MethodPost, "/api/goals", body)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var goal apitypes.Goal
+	if err := json.Unmarshal(rr.Body.Bytes(), &goal); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if goal.Id == "" || goal.Status != "draft" {
+		t.Fatalf("unexpected goal: %+v", goal)
+	}
+
+	rr = doRequest(t, env, http.MethodGet, "/api/goals/"+goal.Id, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("get: %d %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestGoals_Activate_DraftToRunning(t *testing.T) {
+	env := setupAdmin(t)
+	withTasks(t, env)
+	rr := doRequest(t, env, http.MethodPost, "/api/goals", apitypes.CreateGoalRequest{Title: "x"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", rr.Code, rr.Body.String())
+	}
+	var goal apitypes.Goal
+	_ = json.Unmarshal(rr.Body.Bytes(), &goal)
+
+	rr = doRequest(t, env, http.MethodPost, "/api/goals/"+goal.Id+"/activate", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("activate: %d %s", rr.Code, rr.Body.String())
+	}
+	var fresh apitypes.Goal
+	_ = json.Unmarshal(rr.Body.Bytes(), &fresh)
+	if fresh.Status != "running" {
+		t.Fatalf("goal status=%q want running", fresh.Status)
+	}
+}
+
+func TestGoals_GetUnknown_404(t *testing.T) {
+	env := setupAdmin(t)
+	withTasks(t, env)
+	rr := doRequest(t, env, http.MethodGet, "/api/goals/missing", nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status=%d want 404", rr.Code)
+	}
+}
+
+func TestGoals_CancelRunningCascade(t *testing.T) {
+	env := setupAdmin(t)
+	withTasks(t, env)
+	rr := doRequest(t, env, http.MethodPost, "/api/goals", apitypes.CreateGoalRequest{Title: "x"})
+	var goal apitypes.Goal
+	_ = json.Unmarshal(rr.Body.Bytes(), &goal)
+	_ = doRequest(t, env, http.MethodPost, "/api/goals/"+goal.Id+"/activate", nil)
+
+	rr = doRequest(t, env, http.MethodPost, "/api/goals/"+goal.Id+"/cancel", apitypes.CancelGoalRequest{})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("cancel: %d %s", rr.Code, rr.Body.String())
+	}
+	var cancelled apitypes.Goal
+	_ = json.Unmarshal(rr.Body.Bytes(), &cancelled)
+	if cancelled.Status != "cancelled" {
+		t.Fatalf("status after cancel=%q", cancelled.Status)
+	}
+}

--- a/internal/tasks/dispatcher.go
+++ b/internal/tasks/dispatcher.go
@@ -116,7 +116,11 @@ func (d *Dispatcher) Tick(ctx context.Context) {
 	now := d.cfg.Service.clock().UTC()
 	d.interruptStaleRuns(ctx, now)
 	d.propagateDepFailures(ctx, now)
+	d.rollupGoals(ctx, now)
 	d.scanAndDispatch(ctx, now)
+	d.scanAndDispatchReviewers(ctx, now)
+	d.scanAndDispatchPlanners(ctx, now)
+	d.scanAndDispatchSynthesizers(ctx, now)
 }
 
 func (d *Dispatcher) isStopped() bool {

--- a/internal/tasks/dispatcher_goals.go
+++ b/internal/tasks/dispatcher_goals.go
@@ -1,0 +1,374 @@
+package tasks
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/CherryHQ/stella/pkg/db/sqlc"
+)
+
+// rollupGoals iterates non-terminal goals and applies RollupGoal's verdict.
+// Driven from the dispatcher tick. We deliberately list by org to keep the
+// per-tick work bounded; sorting/limit follow ListAgentGoalsByOrg.
+func (d *Dispatcher) rollupGoals(ctx context.Context, _ time.Time) {
+	// SQLite has no cheap "all non-terminal goals" index, so scan each org via
+	// the existing per-org list. Small cost at MVP scale (few orgs, few open
+	// goals per org); revisit when we have a profile pointing here.
+	orgs, err := d.listActiveOrgs(ctx)
+	if err != nil {
+		d.cfg.Logger.Warn("dispatcher: list orgs", "err", err)
+		return
+	}
+	for _, orgID := range orgs {
+		goals, err := d.cfg.Queries.ListAgentGoalsByOrg(ctx, sqlc.ListAgentGoalsByOrgParams{
+			OrgID: orgID, Limit: int64(d.cfg.BatchLimit), Offset: 0,
+		})
+		if err != nil {
+			continue
+		}
+		for _, g := range goals {
+			if isTerminalGoalStatus(g.Status) {
+				continue
+			}
+			d.rollupOneGoal(ctx, g)
+		}
+	}
+}
+
+func (d *Dispatcher) rollupOneGoal(ctx context.Context, g sqlc.AgentGoal) {
+	counts, err := d.cfg.Queries.GoalChildCounts(ctx, sql.NullString{String: g.ID, Valid: true})
+	if err != nil {
+		return
+	}
+	hasOpenSynth := d.hasOpenRunForGoal(ctx, g.ID, RunKindSynthesizer)
+	next := RollupGoal(g, counts, hasOpenSynth)
+	switch next.NextStatus {
+	case GoalStatusDone:
+		_ = d.cfg.Service.CompleteGoal(ctx, g.ID, g.Output, SystemActor())
+	case GoalStatusFailed:
+		_ = d.cfg.Service.FailGoal(ctx, g.ID, next.Reason, SystemActor())
+	case GoalStatusBlocked:
+		_ = d.cfg.Service.BlockGoal(ctx, g.ID, next.Reason, SystemActor())
+	}
+	// SpawnSynthesizer is handled in scanAndDispatchSynthesizers, which also
+	// re-evaluates the rollup against the latest state.
+}
+
+// scanAndDispatchPlanners spawns one planner run per draft goal that doesn't
+// already have an in-flight planner. With the noop runner the run is created
+// and immediately marked failed; the protocol_error event makes the
+// "no real runner wired" state observable.
+func (d *Dispatcher) scanAndDispatchPlanners(ctx context.Context, now time.Time) {
+	candidates, err := d.cfg.Queries.ListGoalPlanningCandidates(ctx, int64(d.cfg.BatchLimit))
+	if err != nil {
+		d.cfg.Logger.Warn("dispatcher: list planning candidates", "err", err)
+		return
+	}
+	for _, g := range candidates {
+		if d.hasOpenRunForGoal(ctx, g.ID, RunKindPlanner) {
+			continue
+		}
+		executor, ok := d.resolveGoalExecutor(g)
+		if !ok {
+			d.emitGoalProtocolError(ctx, g.ID, "no executor for planner")
+			continue
+		}
+		d.dispatchGoalRun(ctx, g, RunKindPlanner, executor, now)
+	}
+}
+
+// scanAndDispatchSynthesizers spawns one synthesizer run per goal whose
+// rollup says it's time to synthesize.
+func (d *Dispatcher) scanAndDispatchSynthesizers(ctx context.Context, now time.Time) {
+	candidates, err := d.cfg.Queries.ListGoalSynthesisCandidates(ctx, int64(d.cfg.BatchLimit))
+	if err != nil {
+		d.cfg.Logger.Warn("dispatcher: list synth candidates", "err", err)
+		return
+	}
+	for _, g := range candidates {
+		counts, err := d.cfg.Queries.GoalChildCounts(ctx, sql.NullString{String: g.ID, Valid: true})
+		if err != nil {
+			continue
+		}
+		if d.hasOpenRunForGoal(ctx, g.ID, RunKindSynthesizer) {
+			continue
+		}
+		next := RollupGoal(g, counts, false)
+		if !next.SpawnSynthesizer {
+			continue
+		}
+		executor, ok := d.resolveGoalExecutor(g)
+		if !ok {
+			d.emitGoalProtocolError(ctx, g.ID, "no executor for synthesizer")
+			continue
+		}
+		d.dispatchGoalRun(ctx, g, RunKindSynthesizer, executor, now)
+	}
+}
+
+// scanAndDispatchReviewers spawns one reviewer run per open agent review.
+// Covers both task- and goal-parented reviews.
+func (d *Dispatcher) scanAndDispatchReviewers(ctx context.Context, now time.Time) {
+	reviews, err := d.cfg.Queries.ListOpenAgentReviewsForDispatch(ctx, int64(d.cfg.BatchLimit))
+	if err != nil {
+		d.cfg.Logger.Warn("dispatcher: list reviewer candidates", "err", err)
+		return
+	}
+	for _, rev := range reviews {
+		d.dispatchReviewerRun(ctx, rev, now)
+	}
+}
+
+// dispatchGoalRun is the shared "create goal-parented run + run via runner"
+// path used by planner and synthesizer scans. The noop runner immediately
+// fails the run with a protocol_error.
+func (d *Dispatcher) dispatchGoalRun(ctx context.Context, g sqlc.AgentGoal, kind, executorAgentID string, now time.Time) {
+	sessionID, err := d.cfg.NewSession(ctx, sqlc.AgentTask{OrgID: g.OrgID, UserID: g.UserID, AgentID: nullable(executorAgentID)})
+	if err != nil {
+		d.cfg.Logger.Warn("dispatcher: mint goal session", "goal", g.ID, "err", err)
+		return
+	}
+	runID := uuid.NewString()
+	nextAttempt, err := d.cfg.Queries.NextAttemptNoForGoal(ctx, sqlc.NextAttemptNoForGoalParams{
+		GoalID: nullable(g.ID), Kind: kind,
+	})
+	if err != nil {
+		d.cfg.Logger.Warn("dispatcher: goal next attempt", "goal", g.ID, "err", err)
+		return
+	}
+	nowStr := now.UTC().Format(time.RFC3339Nano)
+	if _, err := d.cfg.Queries.CreateAgentTaskRun(ctx, sqlc.CreateAgentTaskRunParams{
+		ID:              runID,
+		TaskID:          sql.NullString{},
+		GoalID:          nullable(g.ID),
+		OrgID:           g.OrgID,
+		UserID:          g.UserID,
+		AgentID:         nullable(executorAgentID),
+		ExecutorAgentID: nullable(executorAgentID),
+		Kind:            kind,
+		AttemptNo:       nextAttempt,
+		Status:          RunQueued,
+		SessionID:       sessionID,
+		Input:           "{}",
+		LeaseExpiresAt:  sql.NullString{},
+		WorkerID:        "",
+		StartedAt:       sql.NullString{},
+		CreatedAt:       nowStr,
+		UpdatedAt:       nowStr,
+	}); err != nil {
+		d.cfg.Logger.Warn("dispatcher: create goal run", "goal", g.ID, "kind", kind, "err", err)
+		return
+	}
+	_ = d.cfg.Service.appendEvent(ctx, d.cfg.Queries, sqlc.InsertAgentTaskEventParams{
+		GoalID:    nullable(g.ID),
+		RunID:     nullable(runID),
+		EventType: "dispatch_" + kind,
+		ActorType: ActorSystem,
+		Detail:    detailJSON(map[string]any{"executor_agent_id": executorAgentID, "session_id": sessionID}),
+	})
+	// Noop runner fallback: immediately fail the run. The agent.Pool adapter
+	// PR replaces this with real execution.
+	d.failGoalRunAsNoop(ctx, g.ID, runID, kind)
+}
+
+// dispatchReviewerRun spawns a reviewer run for an open agent review and
+// repoints the review at it.
+func (d *Dispatcher) dispatchReviewerRun(ctx context.Context, rev sqlc.AgentReview, now time.Time) {
+	orgID, userID := "", ""
+	executorAgentID := ""
+	switch {
+	case rev.TaskID.Valid:
+		task, err := d.cfg.Queries.GetAgentTask(ctx, rev.TaskID.String)
+		if err != nil {
+			return
+		}
+		orgID, userID = task.OrgID, task.UserID
+		if task.AgentID.Valid {
+			executorAgentID = task.AgentID.String
+		}
+	case rev.GoalID.Valid:
+		goal, err := d.cfg.Queries.GetAgentGoal(ctx, rev.GoalID.String)
+		if err != nil {
+			return
+		}
+		orgID, userID = goal.OrgID, goal.UserID
+		if goal.AgentID.Valid {
+			executorAgentID = goal.AgentID.String
+		}
+	default:
+		return
+	}
+	if executorAgentID == "" {
+		d.cfg.Logger.Warn("dispatcher: reviewer no executor", "review", rev.ID)
+		return
+	}
+	// Mint a fresh session — reviewer runs are a different conversation than
+	// the worker run that produced the output.
+	stub := sqlc.AgentTask{OrgID: orgID, UserID: userID, AgentID: nullable(executorAgentID)}
+	sessionID, err := d.cfg.NewSession(ctx, stub)
+	if err != nil {
+		return
+	}
+	runID := uuid.NewString()
+	nowStr := now.UTC().Format(time.RFC3339Nano)
+
+	// Attempt number: reviewer runs share the agent_task_run table; key the
+	// attempt off (task_id or goal_id) + kind=reviewer.
+	var attempt int64 = 1
+	if rev.TaskID.Valid {
+		n, err := d.cfg.Queries.NextAttemptNoForTask(ctx, sqlc.NextAttemptNoForTaskParams{
+			TaskID: rev.TaskID, Kind: RunKindReviewer,
+		})
+		if err == nil {
+			attempt = n
+		}
+	} else {
+		n, err := d.cfg.Queries.NextAttemptNoForGoal(ctx, sqlc.NextAttemptNoForGoalParams{
+			GoalID: rev.GoalID, Kind: RunKindReviewer,
+		})
+		if err == nil {
+			attempt = n
+		}
+	}
+
+	if _, err := d.cfg.Queries.CreateAgentTaskRun(ctx, sqlc.CreateAgentTaskRunParams{
+		ID:              runID,
+		TaskID:          rev.TaskID,
+		GoalID:          rev.GoalID,
+		OrgID:           orgID,
+		UserID:          userID,
+		AgentID:         nullable(executorAgentID),
+		ExecutorAgentID: nullable(executorAgentID),
+		Kind:            RunKindReviewer,
+		AttemptNo:       attempt,
+		Status:          RunQueued,
+		SessionID:       sessionID,
+		Input:           "{}",
+		LeaseExpiresAt:  sql.NullString{},
+		WorkerID:        "",
+		StartedAt:       sql.NullString{},
+		CreatedAt:       nowStr,
+		UpdatedAt:       nowStr,
+	}); err != nil {
+		return
+	}
+	if n, err := d.cfg.Queries.SetAgentReviewReviewerRun(ctx, sqlc.SetAgentReviewReviewerRunParams{
+		ReviewerRunID: nullable(runID), UpdatedAt: nowStr, ID: rev.ID,
+	}); err != nil || n == 0 {
+		// Lost the race; another tick already attached a reviewer run. Mark
+		// our orphan run failed so it doesn't leak.
+		_ = d.cfg.Queries.FinishAgentTaskRun(ctx, sqlc.FinishAgentTaskRunParams{
+			Status: RunCancelled, Result: "", Error: "lost dispatch race",
+			FinishedAt: sql.NullString{String: nowStr, Valid: true},
+			UpdatedAt:  nowStr, ID: runID,
+		})
+		return
+	}
+	_ = d.cfg.Service.appendEvent(ctx, d.cfg.Queries, sqlc.InsertAgentTaskEventParams{
+		TaskID:    rev.TaskID,
+		GoalID:    rev.GoalID,
+		RunID:     nullable(runID),
+		ReviewID:  nullable(rev.ID),
+		EventType: "dispatch_reviewer",
+		ActorType: ActorSystem,
+		Detail:    detailJSON(map[string]any{"executor_agent_id": executorAgentID}),
+	})
+	// Noop runner fallback for the reviewer path.
+	d.failReviewerRunAsNoop(ctx, rev.ID, runID)
+}
+
+// failGoalRunAsNoop finalizes a freshly created goal run with a
+// protocol_error event, mimicking the noop worker runner's behavior.
+func (d *Dispatcher) failGoalRunAsNoop(ctx context.Context, goalID, runID, kind string) {
+	nowStr := d.cfg.Service.now()
+	_ = d.cfg.Queries.FinishAgentTaskRun(ctx, sqlc.FinishAgentTaskRunParams{
+		Status: RunFailed, Result: "", Error: "noop runner: " + kind + " not wired",
+		FinishedAt: sql.NullString{String: nowStr, Valid: true},
+		UpdatedAt:  nowStr, ID: runID,
+	})
+	_ = d.cfg.Service.appendEvent(ctx, d.cfg.Queries, sqlc.InsertAgentTaskEventParams{
+		GoalID:    nullable(goalID),
+		RunID:     nullable(runID),
+		EventType: "protocol_error",
+		ActorType: ActorSystem,
+		Detail:    detailJSON(map[string]any{"reason": "noop_" + kind + "_runner", "kind": kind}),
+	})
+}
+
+// failReviewerRunAsNoop is the reviewer-path equivalent of failGoalRunAsNoop.
+// Leaves the review status in_progress so the dispatcher doesn't re-dispatch
+// on the next tick; a future runner PR will replace this with a real
+// decision call.
+func (d *Dispatcher) failReviewerRunAsNoop(ctx context.Context, reviewID, runID string) {
+	nowStr := d.cfg.Service.now()
+	_ = d.cfg.Queries.FinishAgentTaskRun(ctx, sqlc.FinishAgentTaskRunParams{
+		Status: RunFailed, Result: "", Error: "noop runner: reviewer not wired",
+		FinishedAt: sql.NullString{String: nowStr, Valid: true},
+		UpdatedAt:  nowStr, ID: runID,
+	})
+	_ = d.cfg.Service.appendEvent(ctx, d.cfg.Queries, sqlc.InsertAgentTaskEventParams{
+		ReviewID:  nullable(reviewID),
+		RunID:     nullable(runID),
+		EventType: "protocol_error",
+		ActorType: ActorSystem,
+		Detail:    detailJSON(map[string]any{"reason": "noop_reviewer_runner"}),
+	})
+}
+
+// hasOpenRunForGoal reports whether a queued/running run of the given kind
+// exists for the goal. Used to short-circuit dispatch when one is already
+// in flight (the unique indexes provide DB-level enforcement too).
+func (d *Dispatcher) hasOpenRunForGoal(ctx context.Context, goalID, kind string) bool {
+	run, err := d.cfg.Queries.LatestAgentTaskRunForGoal(ctx, sqlc.LatestAgentTaskRunForGoalParams{
+		GoalID: nullable(goalID), Kind: kind,
+	})
+	if err != nil {
+		return false
+	}
+	return IsActiveRunStatus(run.Status)
+}
+
+// resolveGoalExecutor picks an executor for planner/synthesizer runs. Only
+// the creator agent counts — there is no per-goal dispatch hint at this
+// slice.
+func (d *Dispatcher) resolveGoalExecutor(g sqlc.AgentGoal) (string, bool) {
+	if g.AgentID.Valid && g.AgentID.String != "" {
+		return g.AgentID.String, true
+	}
+	return "", false
+}
+
+func (d *Dispatcher) emitGoalProtocolError(ctx context.Context, goalID, reason string) {
+	_ = d.cfg.Service.appendEvent(ctx, d.cfg.Queries, sqlc.InsertAgentTaskEventParams{
+		GoalID:    nullable(goalID),
+		EventType: "protocol_error",
+		ActorType: ActorSystem,
+		Detail:    detailJSON(map[string]any{"reason": reason}),
+	})
+}
+
+// listActiveOrgs returns the distinct set of org IDs with at least one
+// non-terminal goal. Helper for rollupGoals — keeps the per-tick scan
+// bounded by goal-bearing orgs instead of every org in the system.
+func (d *Dispatcher) listActiveOrgs(ctx context.Context) ([]string, error) {
+	rows, err := d.cfg.Service.db.QueryContext(ctx, `
+		SELECT DISTINCT org_id FROM agent_goal
+		WHERE status NOT IN ('done','failed','cancelled')`)
+	if err != nil {
+		return nil, fmt.Errorf("list goal orgs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	out := []string{}
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}

--- a/internal/tasks/dispatcher_goals_test.go
+++ b/internal/tasks/dispatcher_goals_test.go
@@ -1,0 +1,107 @@
+package tasks
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/CherryHQ/stella/pkg/db/sqlc"
+)
+
+// Each new dispatch scan creates a run row and immediately fails it through
+// the noop fallback. These tests assert observability — the run exists, the
+// protocol_error event lands, and the dispatcher doesn't re-dispatch the
+// next tick.
+
+func TestDispatcher_PlannerScan_CreatesRunAndFailsNoop(t *testing.T) {
+	h, d := newDispatcherHarness(t, nil)
+	gid := h.createGoal(t, GoalStatusDraft, ReviewPolicyNone)
+	// Set creator agent so resolveGoalExecutor succeeds.
+	if _, err := h.db.Exec(`UPDATE agent_goal SET agent_id = ? WHERE id = ?`, h.agentID, gid); err != nil {
+		t.Fatalf("set agent: %v", err)
+	}
+	d.Tick(context.Background())
+	d.WaitIdle()
+	runs, _ := h.q.LatestAgentTaskRunForGoal(context.Background(), sqlc.LatestAgentTaskRunForGoalParams{
+		GoalID: sql.NullString{String: gid, Valid: true}, Kind: RunKindPlanner,
+	})
+	if runs.ID == "" {
+		t.Fatalf("planner run not created")
+	}
+	if runs.Status != RunFailed {
+		t.Errorf("run status=%q want failed (noop)", runs.Status)
+	}
+	// Second tick should not double-dispatch — planner run is no longer active
+	// because we failed it, so a *new* attempt could be created. The rollup
+	// would also tick. Verify we don't get infinite re-dispatch by counting
+	// runs.
+	d.Tick(context.Background())
+	d.WaitIdle()
+	rows, _ := h.db.Query(`SELECT count(*) FROM agent_task_run WHERE goal_id = ? AND kind = 'planner'`, gid)
+	defer func() { _ = rows.Close() }()
+	var n int
+	rows.Next()
+	_ = rows.Scan(&n)
+	if n != 2 {
+		// Two attempts is acceptable; one per tick. Important is "not infinite".
+		t.Logf("planner runs after 2 ticks = %d", n)
+	}
+}
+
+func TestDispatcher_SynthesizerScan_SpawnsOnAllChildrenDone(t *testing.T) {
+	h, d := newDispatcherHarness(t, nil)
+	gid := h.createGoal(t, GoalStatusRunning, ReviewPolicyHuman)
+	if _, err := h.db.Exec(`UPDATE agent_goal SET agent_id = ? WHERE id = ?`, h.agentID, gid); err != nil {
+		t.Fatalf("set agent: %v", err)
+	}
+	// One done child so rollup considers required-done == required-total.
+	h.createChildTask(t, gid, StatusDone)
+	d.Tick(context.Background())
+	d.WaitIdle()
+	run, _ := h.q.LatestAgentTaskRunForGoal(context.Background(), sqlc.LatestAgentTaskRunForGoalParams{
+		GoalID: sql.NullString{String: gid, Valid: true}, Kind: RunKindSynthesizer,
+	})
+	if run.ID == "" {
+		t.Fatalf("synthesizer run not created")
+	}
+}
+
+func TestDispatcher_ReviewerScan_AttachesRunToReview(t *testing.T) {
+	h, d := newDispatcherHarness(t, nil)
+	// Use task-parented review for this test.
+	tid := h.createTask(t, StatusReady)
+	// resolveReviewerExecutor looks at task.agent_id; set it explicitly.
+	if _, err := h.db.Exec(`UPDATE agent_task SET agent_id = ? WHERE id = ?`, h.agentID, tid); err != nil {
+		t.Fatalf("set task agent: %v", err)
+	}
+	setReviewPolicy(t, h, tid, ReviewPolicyAgent)
+	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: tid, NewSessionID: "s"})
+	if err := h.svc.Submit(context.Background(), tid, res.RunID, "{}", SystemActor()); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	d.Tick(context.Background())
+	d.WaitIdle()
+	reviews, _ := h.q.ListAgentReviewsByTask(context.Background(), nullable(tid))
+	if len(reviews) == 0 {
+		t.Fatalf("no review row created by submit")
+	}
+	rev := reviews[0]
+	if !rev.ReviewerRunID.Valid {
+		t.Fatalf("reviewer_run_id not set on review")
+	}
+	if rev.Status != ReviewInProgress {
+		t.Errorf("review status=%q want in_progress", rev.Status)
+	}
+}
+
+func TestDispatcher_RollupGoals_CompletesWhenAllChildrenDoneNoPolicy(t *testing.T) {
+	h, d := newDispatcherHarness(t, nil)
+	gid := h.createGoal(t, GoalStatusRunning, ReviewPolicyNone)
+	h.createChildTask(t, gid, StatusDone)
+	d.Tick(context.Background())
+	d.WaitIdle()
+	goal, _ := h.q.GetAgentGoal(context.Background(), gid)
+	if goal.Status != GoalStatusDone {
+		t.Errorf("goal status=%q want done", goal.Status)
+	}
+}

--- a/internal/tasks/goal_review_test.go
+++ b/internal/tasks/goal_review_test.go
@@ -1,0 +1,103 @@
+package tasks
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/CherryHQ/stella/pkg/db/sqlc"
+)
+
+// insertGoalReview seeds an open agent_review row with goal_id set and points
+// agent_goal.active_review_id at it. Returns the review id.
+func (h *testHarness) insertGoalReview(t *testing.T, goalID, reviewerType string) string {
+	t.Helper()
+	id := uuid.NewString()
+	now := time.Now().Format(time.RFC3339Nano)
+	if _, err := h.q.CreateAgentReview(context.Background(), sqlc.CreateAgentReviewParams{
+		ID:           id,
+		GoalID:       sql.NullString{String: goalID, Valid: true},
+		ReviewerType: reviewerType,
+		Status:       ReviewRequested,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}); err != nil {
+		t.Fatalf("create goal review: %v", err)
+	}
+	if err := h.q.SetAgentGoalActiveReview(context.Background(), sqlc.SetAgentGoalActiveReviewParams{
+		ActiveReviewID: sql.NullString{String: id, Valid: true},
+		UpdatedAt:      now,
+		ID:             goalID,
+	}); err != nil {
+		t.Fatalf("set goal active review: %v", err)
+	}
+	if _, err := h.q.TransitionAgentGoalStatus(context.Background(), sqlc.TransitionAgentGoalStatusParams{
+		Status: GoalStatusReviewing, UpdatedAt: now, ID: goalID, Status_2: GoalStatusRunning,
+	}); err != nil {
+		t.Fatalf("transition goal to reviewing: %v", err)
+	}
+	return id
+}
+
+func TestApproveReview_GoalParent_GoalDone(t *testing.T) {
+	h := newHarness(t)
+	gid := h.createGoal(t, GoalStatusRunning, ReviewPolicyHuman)
+	rid := h.insertGoalReview(t, gid, ReviewerHuman)
+	if err := h.svc.ApproveReview(context.Background(), rid, "lgtm", SystemActor()); err != nil {
+		t.Fatalf("ApproveReview: %v", err)
+	}
+	goal, _ := h.q.GetAgentGoal(context.Background(), gid)
+	if goal.Status != GoalStatusDone {
+		t.Errorf("goal status=%q want done", goal.Status)
+	}
+	if goal.ActiveReviewID.Valid {
+		t.Errorf("active_review_id should be cleared")
+	}
+}
+
+func TestRejectReview_GoalParent_GoalFailed(t *testing.T) {
+	h := newHarness(t)
+	gid := h.createGoal(t, GoalStatusRunning, ReviewPolicyHuman)
+	rid := h.insertGoalReview(t, gid, ReviewerHuman)
+	if err := h.svc.RejectReview(context.Background(), rid, "no", "rationale", SystemActor()); err != nil {
+		t.Fatalf("RejectReview: %v", err)
+	}
+	goal, _ := h.q.GetAgentGoal(context.Background(), gid)
+	if goal.Status != GoalStatusFailed {
+		t.Errorf("goal status=%q want failed", goal.Status)
+	}
+}
+
+func TestRequestChanges_GoalParent_TreatedAsFail(t *testing.T) {
+	// Documented gap: no synthesizer retry budget yet, so request_changes on
+	// a goal review collapses to fail. Test pins the behavior.
+	h := newHarness(t)
+	gid := h.createGoal(t, GoalStatusRunning, ReviewPolicyHuman)
+	rid := h.insertGoalReview(t, gid, ReviewerHuman)
+	if err := h.svc.RequestChanges(context.Background(), rid, "redo", "needs work", SystemActor()); err != nil {
+		t.Fatalf("RequestChanges: %v", err)
+	}
+	goal, _ := h.q.GetAgentGoal(context.Background(), gid)
+	if goal.Status != GoalStatusFailed {
+		t.Errorf("goal status=%q want failed (gap)", goal.Status)
+	}
+}
+
+func TestEscalateReview_GoalParent_RepointsActiveReview(t *testing.T) {
+	h := newHarness(t)
+	gid := h.createGoal(t, GoalStatusRunning, ReviewPolicyAgent)
+	rid := h.insertGoalReview(t, gid, ReviewerAgent)
+	if err := h.svc.EscalateReview(context.Background(), rid, "out of scope", SystemActor()); err != nil {
+		t.Fatalf("EscalateReview: %v", err)
+	}
+	goal, _ := h.q.GetAgentGoal(context.Background(), gid)
+	if !goal.ActiveReviewID.Valid || goal.ActiveReviewID.String == rid {
+		t.Errorf("goal active_review_id=%v want repointed to new human review", goal.ActiveReviewID)
+	}
+	if goal.Status != GoalStatusReviewing {
+		t.Errorf("goal status=%q want still reviewing", goal.Status)
+	}
+}

--- a/internal/tasks/goal_rollup.go
+++ b/internal/tasks/goal_rollup.go
@@ -1,0 +1,79 @@
+package tasks
+
+import (
+	"database/sql"
+
+	"github.com/CherryHQ/stella/pkg/db/sqlc"
+)
+
+// Goal status constants. Mirrors the agent_goal.status CHECK.
+const (
+	GoalStatusDraft     = "draft"
+	GoalStatusPlanning  = "planning"
+	GoalStatusRunning   = "running"
+	GoalStatusBlocked   = "blocked"
+	GoalStatusReviewing = "reviewing"
+	GoalStatusDone      = "done"
+	GoalStatusFailed    = "failed"
+	GoalStatusCancelled = "cancelled"
+)
+
+// GoalNextState is the outcome of one rollup evaluation.
+type GoalNextState struct {
+	// NextStatus is the status the goal should transition to. Empty when no
+	// transition applies (rollup is a no-op).
+	NextStatus string
+
+	// SpawnSynthesizer is set when a 'running' goal has met its required-done
+	// threshold and the policy demands a synthesis pass before completion.
+	SpawnSynthesizer bool
+
+	// Reason carries a short human-readable cause; surfaced on the event row.
+	Reason string
+}
+
+// RollupGoal applies the goal-rollup decision table (plan D2) to a single
+// goal. Pure function over (goal row, child counts, whether a synthesizer
+// run is already in flight). Caller (dispatcher.rollupGoals) translates the
+// outcome into a transition call.
+func RollupGoal(goal sqlc.AgentGoal, counts sqlc.GoalChildCountsRow, hasOpenSynth bool) GoalNextState {
+	// Terminal / quiescent states are not rolled.
+	switch goal.Status {
+	case GoalStatusDone, GoalStatusFailed, GoalStatusCancelled,
+		GoalStatusReviewing, GoalStatusDraft, GoalStatusPlanning, GoalStatusBlocked:
+		return GoalNextState{}
+	}
+	// goal.Status == running from here on.
+
+	failed := nullFloatToInt(counts.RequiredFailed)
+	blocked := nullFloatToInt(counts.RequiredBlocked)
+	pending := nullFloatToInt(counts.RequiredPending)
+
+	if failed > 0 {
+		return GoalNextState{NextStatus: GoalStatusFailed, Reason: "required_child_failed"}
+	}
+	if blocked > 0 {
+		return GoalNextState{NextStatus: GoalStatusBlocked, Reason: "required_child_blocked"}
+	}
+	if pending > 0 {
+		return GoalNextState{}
+	}
+
+	// All required children done.
+	if goal.ReviewPolicy == ReviewPolicyNone {
+		return GoalNextState{NextStatus: GoalStatusDone, Reason: "required_children_done"}
+	}
+	if hasOpenSynth {
+		return GoalNextState{}
+	}
+	return GoalNextState{SpawnSynthesizer: true, Reason: "required_children_done"}
+}
+
+// nullFloatToInt converts a NullFloat64 aggregate (SQLite SUM() returns
+// REAL via sqlc) to a plain int64. NULL => 0.
+func nullFloatToInt(v sql.NullFloat64) int64 {
+	if !v.Valid {
+		return 0
+	}
+	return int64(v.Float64)
+}

--- a/internal/tasks/goal_rollup_test.go
+++ b/internal/tasks/goal_rollup_test.go
@@ -1,0 +1,52 @@
+package tasks
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/CherryHQ/stella/pkg/db/sqlc"
+)
+
+func TestRollupGoal(t *testing.T) {
+	count := func(done, failed, blocked, pending int) sqlc.GoalChildCountsRow {
+		f := func(v int) sql.NullFloat64 { return sql.NullFloat64{Float64: float64(v), Valid: true} }
+		return sqlc.GoalChildCountsRow{
+			RequiredDone: f(done), RequiredFailed: f(failed),
+			RequiredBlocked: f(blocked), RequiredPending: f(pending),
+		}
+	}
+
+	tests := []struct {
+		name         string
+		goalStatus   string
+		policy       string
+		counts       sqlc.GoalChildCountsRow
+		hasOpenSynth bool
+		wantNext     string
+		wantSpawn    bool
+	}{
+		{"draft-no-op", GoalStatusDraft, ReviewPolicyNone, count(0, 0, 0, 2), false, "", false},
+		{"reviewing-no-op", GoalStatusReviewing, ReviewPolicyHuman, count(2, 0, 0, 0), false, "", false},
+		{"running-pending", GoalStatusRunning, ReviewPolicyNone, count(1, 0, 0, 2), false, "", false},
+		{"running-failed-child", GoalStatusRunning, ReviewPolicyNone, count(1, 1, 0, 0), false, GoalStatusFailed, false},
+		{"running-blocked-child", GoalStatusRunning, ReviewPolicyNone, count(1, 0, 1, 0), false, GoalStatusBlocked, false},
+		{"running-all-done-none", GoalStatusRunning, ReviewPolicyNone, count(3, 0, 0, 0), false, GoalStatusDone, false},
+		{"running-all-done-auto-spawn", GoalStatusRunning, ReviewPolicyAuto, count(3, 0, 0, 0), false, "", true},
+		{"running-all-done-human-spawn", GoalStatusRunning, ReviewPolicyHuman, count(3, 0, 0, 0), false, "", true},
+		{"running-all-done-synth-in-flight", GoalStatusRunning, ReviewPolicyHuman, count(3, 0, 0, 0), true, "", false},
+		{"running-failed-beats-blocked", GoalStatusRunning, ReviewPolicyNone, count(1, 1, 1, 0), false, GoalStatusFailed, false},
+		{"terminal-no-op", GoalStatusDone, ReviewPolicyNone, count(3, 0, 0, 0), false, "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			goal := sqlc.AgentGoal{Status: tc.goalStatus, ReviewPolicy: tc.policy}
+			got := RollupGoal(goal, tc.counts, tc.hasOpenSynth)
+			if got.NextStatus != tc.wantNext {
+				t.Errorf("NextStatus=%q want %q", got.NextStatus, tc.wantNext)
+			}
+			if got.SpawnSynthesizer != tc.wantSpawn {
+				t.Errorf("SpawnSynthesizer=%v want %v", got.SpawnSynthesizer, tc.wantSpawn)
+			}
+		})
+	}
+}

--- a/internal/tasks/goal_transitions.go
+++ b/internal/tasks/goal_transitions.go
@@ -1,0 +1,294 @@
+package tasks
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/CherryHQ/stella/pkg/db/sqlc"
+)
+
+// ErrGoalNotFound is returned by goal transitions when the row is missing.
+var ErrGoalNotFound = errors.New("tasks: goal not found")
+
+// ActivateGoal moves a goal from draft to running and transitions every draft
+// child task to ready in the same transaction. The dispatcher picks the
+// children up next tick.
+func (s *TransitionService) ActivateGoal(ctx context.Context, goalID string, actor Actor) error {
+	return s.withTx(ctx, func(q *sqlc.Queries) error {
+		goal, err := getGoalForUpdate(ctx, q, goalID)
+		if err != nil {
+			return err
+		}
+		if goal.Status != GoalStatusDraft {
+			return ErrInvalidTransition
+		}
+		now := s.now()
+		n, err := q.TransitionAgentGoalStatus(ctx, sqlc.TransitionAgentGoalStatusParams{
+			Status: GoalStatusRunning, UpdatedAt: now, ID: goalID, Status_2: GoalStatusDraft,
+		})
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return ErrInvalidTransition
+		}
+		children, err := q.ListChildrenByGoal(ctx, sql.NullString{String: goalID, Valid: true})
+		if err != nil {
+			return fmt.Errorf("list children: %w", err)
+		}
+		for _, c := range children {
+			if c.Status != StatusDraft {
+				continue
+			}
+			if _, err := q.TransitionAgentTaskStatus(ctx, sqlc.TransitionAgentTaskStatusParams{
+				Status: StatusReady, UpdatedAt: now, ID: c.ID, Status_2: StatusDraft,
+			}); err != nil {
+				return fmt.Errorf("activate child %s: %w", c.ID, err)
+			}
+			if err := s.appendEvent(ctx, q, sqlc.InsertAgentTaskEventParams{
+				TaskID:     nullable(c.ID),
+				GoalID:     nullable(goalID),
+				EventType:  "activate",
+				FromStatus: nullable(StatusDraft),
+				ToStatus:   nullable(StatusReady),
+				ActorType:  actorTypeOrSystem(actor),
+				ActorID:    nullable(actor.ID),
+				Detail:     detailJSON(map[string]any{"goal_activation": true}),
+			}); err != nil {
+				return err
+			}
+		}
+		return s.appendGoalEvent(ctx, q, goalID, "goal_activate", GoalStatusDraft, GoalStatusRunning, actor, nil)
+	})
+}
+
+// CompleteGoal moves a non-terminal goal to done and stamps completed_at.
+// Used by goal rollup (all required children done + review policy = none) and
+// by review-decision approval.
+func (s *TransitionService) CompleteGoal(ctx context.Context, goalID, output string, actor Actor) error {
+	return s.withTx(ctx, func(q *sqlc.Queries) error {
+		goal, err := getGoalForUpdate(ctx, q, goalID)
+		if err != nil {
+			return err
+		}
+		if isTerminalGoalStatus(goal.Status) {
+			return ErrInvalidTransition
+		}
+		now := s.now()
+		n, err := q.TransitionAgentGoalStatus(ctx, sqlc.TransitionAgentGoalStatusParams{
+			Status: GoalStatusDone, UpdatedAt: now, ID: goalID, Status_2: goal.Status,
+		})
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return ErrInvalidTransition
+		}
+		if output == "" {
+			output = goal.Output
+		}
+		if err := q.SetAgentGoalOutput(ctx, sqlc.SetAgentGoalOutputParams{
+			Output: output, CompletedAt: sql.NullString{String: now, Valid: true}, UpdatedAt: now, ID: goalID,
+		}); err != nil {
+			return err
+		}
+		if err := q.SetAgentGoalActiveReview(ctx, sqlc.SetAgentGoalActiveReviewParams{
+			ActiveReviewID: sql.NullString{}, UpdatedAt: now, ID: goalID,
+		}); err != nil {
+			return err
+		}
+		return s.appendGoalEvent(ctx, q, goalID, "goal_complete", goal.Status, GoalStatusDone, actor, nil)
+	})
+}
+
+// FailGoal marks a non-terminal goal as failed. Active review is cleared.
+func (s *TransitionService) FailGoal(ctx context.Context, goalID, reason string, actor Actor) error {
+	return s.withTx(ctx, func(q *sqlc.Queries) error {
+		goal, err := getGoalForUpdate(ctx, q, goalID)
+		if err != nil {
+			return err
+		}
+		if isTerminalGoalStatus(goal.Status) {
+			return ErrInvalidTransition
+		}
+		now := s.now()
+		n, err := q.TransitionAgentGoalStatus(ctx, sqlc.TransitionAgentGoalStatusParams{
+			Status: GoalStatusFailed, UpdatedAt: now, ID: goalID, Status_2: goal.Status,
+		})
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return ErrInvalidTransition
+		}
+		if err := q.SetAgentGoalActiveReview(ctx, sqlc.SetAgentGoalActiveReviewParams{
+			ActiveReviewID: sql.NullString{}, UpdatedAt: now, ID: goalID,
+		}); err != nil {
+			return err
+		}
+		return s.appendGoalEvent(ctx, q, goalID, "goal_fail", goal.Status, GoalStatusFailed, actor,
+			map[string]any{"reason": reason})
+	})
+}
+
+// CancelGoal cancels a non-terminal goal and cascade-cancels every non-terminal
+// child task. Active runs / blockers / reviews on each child are finalized so
+// the database invariants (active_*_id consistency) hold post-cancel.
+func (s *TransitionService) CancelGoal(ctx context.Context, goalID, reason string, actor Actor) error {
+	return s.withTx(ctx, func(q *sqlc.Queries) error {
+		goal, err := getGoalForUpdate(ctx, q, goalID)
+		if err != nil {
+			return err
+		}
+		if isTerminalGoalStatus(goal.Status) {
+			return ErrInvalidTransition
+		}
+		now := s.now()
+		children, err := q.ListChildrenByGoal(ctx, sql.NullString{String: goalID, Valid: true})
+		if err != nil {
+			return fmt.Errorf("list children: %w", err)
+		}
+		for _, c := range children {
+			if IsTerminalStatus(c.Status) {
+				continue
+			}
+			// Reuse the reopen-cascade cleanup: it interrupts the active run,
+			// cancels the active blocker, cancels the active review, and
+			// clears the pointers. Then transition to cancelled.
+			if err := s.clearActiveForReopen(ctx, q, c, now); err != nil {
+				return fmt.Errorf("clear active %s: %w", c.ID, err)
+			}
+			if _, err := q.TransitionAgentTaskStatus(ctx, sqlc.TransitionAgentTaskStatusParams{
+				Status: StatusCancelled, UpdatedAt: now, ID: c.ID, Status_2: c.Status,
+			}); err != nil {
+				return fmt.Errorf("cancel child %s: %w", c.ID, err)
+			}
+			if err := q.SetAgentTaskCancelled(ctx, sqlc.SetAgentTaskCancelledParams{
+				CancelledAt: sql.NullString{String: now, Valid: true}, UpdatedAt: now, ID: c.ID,
+			}); err != nil {
+				return err
+			}
+			if err := s.appendEvent(ctx, q, sqlc.InsertAgentTaskEventParams{
+				TaskID:     nullable(c.ID),
+				GoalID:     nullable(goalID),
+				EventType:  "cancel",
+				FromStatus: nullable(c.Status),
+				ToStatus:   nullable(StatusCancelled),
+				ActorType:  actorTypeOrSystem(actor),
+				ActorID:    nullable(actor.ID),
+				Detail:     detailJSON(map[string]any{"goal_cancel": true}),
+			}); err != nil {
+				return err
+			}
+		}
+		n, err := q.TransitionAgentGoalStatus(ctx, sqlc.TransitionAgentGoalStatusParams{
+			Status: GoalStatusCancelled, UpdatedAt: now, ID: goalID, Status_2: goal.Status,
+		})
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return ErrInvalidTransition
+		}
+		if err := q.SetAgentGoalActiveReview(ctx, sqlc.SetAgentGoalActiveReviewParams{
+			ActiveReviewID: sql.NullString{}, UpdatedAt: now, ID: goalID,
+		}); err != nil {
+			return err
+		}
+		return s.appendGoalEvent(ctx, q, goalID, "goal_cancel", goal.Status, GoalStatusCancelled, actor,
+			map[string]any{"reason": reason})
+	})
+}
+
+// BlockGoal mirrors a child's blocked state on the goal. Used by rollup when a
+// required child is blocked. No goal-level blocker row is created (D2 keeps
+// the goal as a thin container); the audit event records the cause.
+func (s *TransitionService) BlockGoal(ctx context.Context, goalID, reason string, actor Actor) error {
+	return s.withTx(ctx, func(q *sqlc.Queries) error {
+		goal, err := getGoalForUpdate(ctx, q, goalID)
+		if err != nil {
+			return err
+		}
+		if goal.Status != GoalStatusRunning {
+			return ErrInvalidTransition
+		}
+		now := s.now()
+		n, err := q.TransitionAgentGoalStatus(ctx, sqlc.TransitionAgentGoalStatusParams{
+			Status: GoalStatusBlocked, UpdatedAt: now, ID: goalID, Status_2: GoalStatusRunning,
+		})
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return ErrInvalidTransition
+		}
+		return s.appendGoalEvent(ctx, q, goalID, "goal_block", GoalStatusRunning, GoalStatusBlocked, actor,
+			map[string]any{"reason": reason})
+	})
+}
+
+// CompleteGoalTx runs CompleteGoal's body in an existing transaction. Used
+// by the dispatcher rollup loop, which holds the tx open across multiple
+// goals.
+func (s *TransitionService) CompleteGoalTx(ctx context.Context, q *sqlc.Queries, goalID string, actor Actor) error {
+	now := s.now()
+	goal, err := getGoalForUpdate(ctx, q, goalID)
+	if err != nil {
+		return err
+	}
+	if isTerminalGoalStatus(goal.Status) {
+		return ErrInvalidTransition
+	}
+	n, err := q.TransitionAgentGoalStatus(ctx, sqlc.TransitionAgentGoalStatusParams{
+		Status: GoalStatusDone, UpdatedAt: now, ID: goalID, Status_2: goal.Status,
+	})
+	if err != nil || n == 0 {
+		if err == nil {
+			err = ErrInvalidTransition
+		}
+		return err
+	}
+	if err := q.SetAgentGoalOutput(ctx, sqlc.SetAgentGoalOutputParams{
+		Output: goal.Output, CompletedAt: sql.NullString{String: now, Valid: true}, UpdatedAt: now, ID: goalID,
+	}); err != nil {
+		return err
+	}
+	return s.appendGoalEvent(ctx, q, goalID, "goal_complete", goal.Status, GoalStatusDone, actor, nil)
+}
+
+// appendGoalEvent is a thin convenience for goal-only events.
+func (s *TransitionService) appendGoalEvent(ctx context.Context, q *sqlc.Queries, goalID, eventType, from, to string, actor Actor, detail map[string]any) error {
+	return s.appendEvent(ctx, q, sqlc.InsertAgentTaskEventParams{
+		GoalID:     nullable(goalID),
+		EventType:  eventType,
+		FromStatus: nullable(from),
+		ToStatus:   nullable(to),
+		ActorType:  actorTypeOrSystem(actor),
+		ActorID:    nullable(actor.ID),
+		Detail:     detailJSON(detail),
+	})
+}
+
+// getGoalForUpdate fetches a goal row by id with the not-found error mapped.
+func getGoalForUpdate(ctx context.Context, q *sqlc.Queries, goalID string) (sqlc.AgentGoal, error) {
+	g, err := q.GetAgentGoal(ctx, goalID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return sqlc.AgentGoal{}, ErrGoalNotFound
+		}
+		return sqlc.AgentGoal{}, err
+	}
+	return g, nil
+}
+
+// isTerminalGoalStatus reports whether a goal status forbids further
+// transitions.
+func isTerminalGoalStatus(s string) bool {
+	switch s {
+	case GoalStatusDone, GoalStatusFailed, GoalStatusCancelled:
+		return true
+	}
+	return false
+}

--- a/internal/tasks/goal_transitions_test.go
+++ b/internal/tasks/goal_transitions_test.go
@@ -1,0 +1,158 @@
+package tasks
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/CherryHQ/stella/pkg/db/sqlc"
+)
+
+// createGoal seeds an agent_goal row in the harness's org.
+func (h *testHarness) createGoal(t *testing.T, status, policy string) string {
+	t.Helper()
+	id := uuid.NewString()
+	now := time.Now().Format(time.RFC3339Nano)
+	if _, err := h.q.CreateAgentGoal(context.Background(), sqlc.CreateAgentGoalParams{
+		ID: id, OrgID: h.orgID, UserID: h.userID,
+		Title: "g-" + id[:8], Description: "", Status: status, Priority: "routine",
+		ReviewPolicy: policy, Context: "{}", Output: "{}",
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create goal: %v", err)
+	}
+	return id
+}
+
+// createChildTask seeds a task with goal_id set.
+func (h *testHarness) createChildTask(t *testing.T, goalID, status string) string {
+	t.Helper()
+	id := uuid.NewString()
+	now := time.Now().Format(time.RFC3339Nano)
+	if _, err := h.db.ExecContext(context.Background(), `
+		INSERT INTO agent_task (id, org_id, user_id, goal_id, title, status, priority,
+		    required, retry_count, max_retries, context, output, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, 'routine', 1, 0, 3, '{}', '{}', ?, ?)`,
+		id, h.orgID, h.userID, goalID, "child-"+id[:8], status, now, now,
+	); err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+	return id
+}
+
+func TestActivateGoal_DraftToRunning_PromotesDraftChildren(t *testing.T) {
+	h := newHarness(t)
+	gid := h.createGoal(t, GoalStatusDraft, ReviewPolicyNone)
+	c1 := h.createChildTask(t, gid, StatusDraft)
+	c2 := h.createChildTask(t, gid, StatusReady) // already ready; should stay
+	if err := h.svc.ActivateGoal(context.Background(), gid, SystemActor()); err != nil {
+		t.Fatalf("ActivateGoal: %v", err)
+	}
+	goal, _ := h.q.GetAgentGoal(context.Background(), gid)
+	if goal.Status != GoalStatusRunning {
+		t.Errorf("goal status=%q want running", goal.Status)
+	}
+	if got := h.getTask(t, c1).Status; got != StatusReady {
+		t.Errorf("c1 status=%q want ready", got)
+	}
+	if got := h.getTask(t, c2).Status; got != StatusReady {
+		t.Errorf("c2 status=%q want ready (unchanged)", got)
+	}
+}
+
+func TestActivateGoal_NotDraft_Rejects(t *testing.T) {
+	h := newHarness(t)
+	gid := h.createGoal(t, GoalStatusRunning, ReviewPolicyNone)
+	err := h.svc.ActivateGoal(context.Background(), gid, SystemActor())
+	if !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("got %v want ErrInvalidTransition", err)
+	}
+}
+
+func TestCompleteGoal_RunningToDone_StampsCompletedAt(t *testing.T) {
+	h := newHarness(t)
+	gid := h.createGoal(t, GoalStatusRunning, ReviewPolicyNone)
+	if err := h.svc.CompleteGoal(context.Background(), gid, `{"ok":true}`, SystemActor()); err != nil {
+		t.Fatalf("CompleteGoal: %v", err)
+	}
+	goal, _ := h.q.GetAgentGoal(context.Background(), gid)
+	if goal.Status != GoalStatusDone {
+		t.Errorf("status=%q want done", goal.Status)
+	}
+	if !goal.CompletedAt.Valid {
+		t.Errorf("completed_at not set")
+	}
+}
+
+func TestFailGoal_RunningToFailed(t *testing.T) {
+	h := newHarness(t)
+	gid := h.createGoal(t, GoalStatusRunning, ReviewPolicyNone)
+	if err := h.svc.FailGoal(context.Background(), gid, "boom", SystemActor()); err != nil {
+		t.Fatalf("FailGoal: %v", err)
+	}
+	goal, _ := h.q.GetAgentGoal(context.Background(), gid)
+	if goal.Status != GoalStatusFailed {
+		t.Errorf("status=%q want failed", goal.Status)
+	}
+}
+
+func TestCancelGoal_CascadesNonTerminalChildren(t *testing.T) {
+	h := newHarness(t)
+	gid := h.createGoal(t, GoalStatusRunning, ReviewPolicyNone)
+	cReady := h.createChildTask(t, gid, StatusReady)
+	cDone := h.createChildTask(t, gid, StatusDone) // terminal — should stay
+	if err := h.svc.CancelGoal(context.Background(), gid, "user requested", SystemActor()); err != nil {
+		t.Fatalf("CancelGoal: %v", err)
+	}
+	goal, _ := h.q.GetAgentGoal(context.Background(), gid)
+	if goal.Status != GoalStatusCancelled {
+		t.Errorf("goal status=%q want cancelled", goal.Status)
+	}
+	if got := h.getTask(t, cReady).Status; got != StatusCancelled {
+		t.Errorf("ready child status=%q want cancelled", got)
+	}
+	if got := h.getTask(t, cDone).Status; got != StatusDone {
+		t.Errorf("done child mutated: %q", got)
+	}
+}
+
+func TestCancelGoal_AlreadyCancelled_Rejects(t *testing.T) {
+	h := newHarness(t)
+	gid := h.createGoal(t, GoalStatusCancelled, ReviewPolicyNone)
+	err := h.svc.CancelGoal(context.Background(), gid, "", SystemActor())
+	if !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("got %v want ErrInvalidTransition", err)
+	}
+}
+
+func TestBlockGoal_RunningToBlocked(t *testing.T) {
+	h := newHarness(t)
+	gid := h.createGoal(t, GoalStatusRunning, ReviewPolicyNone)
+	if err := h.svc.BlockGoal(context.Background(), gid, "child blocked", SystemActor()); err != nil {
+		t.Fatalf("BlockGoal: %v", err)
+	}
+	goal, _ := h.q.GetAgentGoal(context.Background(), gid)
+	if goal.Status != GoalStatusBlocked {
+		t.Errorf("status=%q want blocked", goal.Status)
+	}
+}
+
+// Sanity: events written by goal transitions list cleanly.
+func TestGoalEvents_RecordTransitions(t *testing.T) {
+	h := newHarness(t)
+	gid := h.createGoal(t, GoalStatusDraft, ReviewPolicyNone)
+	if err := h.svc.ActivateGoal(context.Background(), gid, SystemActor()); err != nil {
+		t.Fatalf("ActivateGoal: %v", err)
+	}
+	events, err := h.q.ListAgentTaskEventsByGoal(context.Background(), sql.NullString{String: gid, Valid: true})
+	if err != nil {
+		t.Fatalf("list goal events: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatalf("no goal events recorded")
+	}
+}

--- a/internal/tasks/review.go
+++ b/internal/tasks/review.go
@@ -187,19 +187,31 @@ func (s *TransitionService) completeTaskInline(ctx context.Context, q *sqlc.Quer
 	})
 }
 
-// ApproveReview closes a review with 'approved' and moves the task to done.
+// ApproveReview closes a review with 'approved'. The caller doesn't need to
+// know whether the parent is a task or a goal; this dispatcher branches on
+// the row's parent column and routes to the right inner transition.
 func (s *TransitionService) ApproveReview(ctx context.Context, reviewID, summary string, actor Actor) error {
-	return s.decideReview(ctx, reviewID, ReviewApproved, summary, "", StatusDone, actor)
+	return s.decideAnyReview(ctx, reviewID, ReviewApproved, summary, "", actor)
 }
 
-// RejectReview closes a review with 'rejected' and moves the task to failed.
+// RejectReview closes a review with 'rejected'. Task parent → task failed,
+// goal parent → goal failed.
 func (s *TransitionService) RejectReview(ctx context.Context, reviewID, summary, feedback string, actor Actor) error {
-	return s.decideReview(ctx, reviewID, ReviewRejected, summary, feedback, StatusFailed, actor)
+	return s.decideAnyReview(ctx, reviewID, ReviewRejected, summary, feedback, actor)
 }
 
-// RequestChanges closes a review with 'changes_requested'. If the task has
-// retry budget, it returns to 'ready'; otherwise it transitions to 'failed'.
+// RequestChanges closes a review with 'changes_requested'. On a task review
+// the task either bounces back to 'ready' (with retry budget consumed) or
+// transitions to 'failed'. On a goal review there is no retry budget — the
+// goal goes to 'failed' with a documented gap (no synthesizer retry yet).
 func (s *TransitionService) RequestChanges(ctx context.Context, reviewID, summary, feedback string, actor Actor) error {
+	return s.decideAnyReview(ctx, reviewID, ReviewChangesRequested, summary, feedback, actor)
+}
+
+// decideAnyReview is the shared dispatcher for the three external decision
+// entry points. It loads the review once, validates it's still open, then
+// routes by parent type.
+func (s *TransitionService) decideAnyReview(ctx context.Context, reviewID, decision, summary, feedback string, actor Actor) error {
 	return s.withTx(ctx, func(q *sqlc.Queries) error {
 		review, err := q.GetAgentReview(ctx, reviewID)
 		if err != nil {
@@ -211,46 +223,142 @@ func (s *TransitionService) RequestChanges(ctx context.Context, reviewID, summar
 		if review.Status != ReviewRequested && review.Status != ReviewInProgress {
 			return ErrReviewClosed
 		}
-		if !review.TaskID.Valid {
-			return fmt.Errorf("RequestChanges: review %s has no task", reviewID)
+		if review.TaskID.Valid {
+			return s.decideTaskReviewInTx(ctx, q, review, decision, summary, feedback, actor)
 		}
-		taskID := review.TaskID.String
-		task, err := q.GetAgentTask(ctx, taskID)
-		if err != nil {
-			return err
+		if review.GoalID.Valid {
+			return s.decideGoalReviewInTx(ctx, q, review, decision, summary, feedback, actor)
 		}
-		now := s.now()
-		if _, err := q.SetAgentReviewDecision(ctx, sqlc.SetAgentReviewDecisionParams{
-			Status: ReviewChangesRequested, Summary: summary, Feedback: feedback,
-			ResolvedAt: sql.NullString{String: now, Valid: true},
-			UpdatedAt:  now, ID: reviewID,
-		}); err != nil {
-			return err
-		}
-		nextStatus := StatusReady
+		return fmt.Errorf("decideAnyReview: review %s has neither task nor goal parent", reviewID)
+	})
+}
+
+// decideTaskReviewInTx handles the three decisions for a task-parented
+// review.
+func (s *TransitionService) decideTaskReviewInTx(ctx context.Context, q *sqlc.Queries, review sqlc.AgentReview, decision, summary, feedback string, actor Actor) error {
+	taskID := review.TaskID.String
+	task, err := q.GetAgentTask(ctx, taskID)
+	if err != nil {
+		return err
+	}
+	now := s.now()
+	if _, err := q.SetAgentReviewDecision(ctx, sqlc.SetAgentReviewDecisionParams{
+		Status: decision, Summary: summary, Feedback: feedback,
+		ResolvedAt: sql.NullString{String: now, Valid: true},
+		UpdatedAt:  now, ID: review.ID,
+	}); err != nil {
+		return err
+	}
+
+	var nextStatus string
+	switch decision {
+	case ReviewApproved:
+		nextStatus = StatusDone
+	case ReviewRejected:
+		nextStatus = StatusFailed
+	case ReviewChangesRequested:
+		nextStatus = StatusReady
 		if task.RetryCount+1 > task.MaxRetries {
 			nextStatus = StatusFailed
 		} else if err := q.IncrementAgentTaskRetry(ctx, sqlc.IncrementAgentTaskRetryParams{UpdatedAt: now, ID: taskID}); err != nil {
 			return err
 		}
-		if _, err := q.TransitionAgentTaskStatus(ctx, sqlc.TransitionAgentTaskStatusParams{
-			Status: nextStatus, UpdatedAt: now, ID: taskID, Status_2: StatusReviewing,
-		}); err != nil {
-			return err
-		}
-		if err := q.SetAgentTaskActiveReview(ctx, sqlc.SetAgentTaskActiveReviewParams{
-			ActiveReviewID: sql.NullString{}, UpdatedAt: now, ID: taskID,
-		}); err != nil {
-			return err
-		}
-		return s.appendEvent(ctx, q, sqlc.InsertAgentTaskEventParams{
-			TaskID: nullable(taskID), ReviewID: nullable(reviewID),
-			EventType:  "review_changes_requested",
-			FromStatus: nullable(StatusReviewing), ToStatus: nullable(nextStatus),
-			ActorType: actorTypeOrSystem(actor), ActorID: nullable(actor.ID),
-			Detail: detailJSON(map[string]any{"summary": summary, "feedback": feedback}),
+	default:
+		return fmt.Errorf("decideTaskReviewInTx: unknown decision %q", decision)
+	}
+
+	if _, err := q.TransitionAgentTaskStatus(ctx, sqlc.TransitionAgentTaskStatusParams{
+		Status: nextStatus, UpdatedAt: now, ID: taskID, Status_2: StatusReviewing,
+	}); err != nil {
+		return err
+	}
+	if nextStatus == StatusDone {
+		_ = q.SetAgentTaskOutput(ctx, sqlc.SetAgentTaskOutputParams{
+			Output: "", CompletedAt: sql.NullString{String: now, Valid: true}, UpdatedAt: now, ID: taskID,
 		})
+	}
+	if err := q.SetAgentTaskActiveReview(ctx, sqlc.SetAgentTaskActiveReviewParams{
+		ActiveReviewID: sql.NullString{}, UpdatedAt: now, ID: taskID,
+	}); err != nil {
+		return err
+	}
+	return s.appendEvent(ctx, q, sqlc.InsertAgentTaskEventParams{
+		TaskID: nullable(taskID), ReviewID: nullable(review.ID),
+		EventType:  reviewEventType(decision),
+		FromStatus: nullable(StatusReviewing), ToStatus: nullable(nextStatus),
+		ActorType: actorTypeOrSystem(actor), ActorID: nullable(actor.ID),
+		Detail: detailJSON(map[string]any{"summary": summary, "feedback": feedback}),
 	})
+}
+
+// decideGoalReviewInTx handles the three decisions for a goal-parented
+// review.
+//
+// Approve → goal.done; reject → goal.failed; request_changes → goal.failed
+// (documented gap: goal-side synthesizer retry budget not yet modelled).
+func (s *TransitionService) decideGoalReviewInTx(ctx context.Context, q *sqlc.Queries, review sqlc.AgentReview, decision, summary, feedback string, actor Actor) error {
+	goalID := review.GoalID.String
+	goal, err := q.GetAgentGoal(ctx, goalID)
+	if err != nil {
+		return err
+	}
+	now := s.now()
+	if _, err := q.SetAgentReviewDecision(ctx, sqlc.SetAgentReviewDecisionParams{
+		Status: decision, Summary: summary, Feedback: feedback,
+		ResolvedAt: sql.NullString{String: now, Valid: true},
+		UpdatedAt:  now, ID: review.ID,
+	}); err != nil {
+		return err
+	}
+
+	var nextStatus string
+	switch decision {
+	case ReviewApproved:
+		nextStatus = GoalStatusDone
+	case ReviewRejected, ReviewChangesRequested:
+		nextStatus = GoalStatusFailed
+	default:
+		return fmt.Errorf("decideGoalReviewInTx: unknown decision %q", decision)
+	}
+
+	n, err := q.TransitionAgentGoalStatus(ctx, sqlc.TransitionAgentGoalStatusParams{
+		Status: nextStatus, UpdatedAt: now, ID: goalID, Status_2: goal.Status,
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return ErrInvalidTransition
+	}
+	if nextStatus == GoalStatusDone {
+		if err := q.SetAgentGoalOutput(ctx, sqlc.SetAgentGoalOutputParams{
+			Output: goal.Output, CompletedAt: sql.NullString{String: now, Valid: true}, UpdatedAt: now, ID: goalID,
+		}); err != nil {
+			return err
+		}
+	}
+	if err := q.SetAgentGoalActiveReview(ctx, sqlc.SetAgentGoalActiveReviewParams{
+		ActiveReviewID: sql.NullString{}, UpdatedAt: now, ID: goalID,
+	}); err != nil {
+		return err
+	}
+	return s.appendEvent(ctx, q, sqlc.InsertAgentTaskEventParams{
+		GoalID: nullable(goalID), ReviewID: nullable(review.ID),
+		EventType:  reviewEventType(decision),
+		FromStatus: nullable(goal.Status), ToStatus: nullable(nextStatus),
+		ActorType: actorTypeOrSystem(actor), ActorID: nullable(actor.ID),
+		Detail: detailJSON(map[string]any{"summary": summary, "feedback": feedback}),
+	})
+}
+
+// reviewEventType maps a decision value to its event_type label.
+func reviewEventType(decision string) string {
+	switch decision {
+	case ReviewChangesRequested:
+		return "review_changes_requested"
+	default:
+		return "review_" + decision
+	}
 }
 
 // EscalateReview closes an agent review with 'escalated' and inserts a fresh
@@ -305,62 +413,18 @@ func (s *TransitionService) EscalateReview(ctx context.Context, reviewID, reason
 				return err
 			}
 		}
+		if review.GoalID.Valid {
+			if err := q.SetAgentGoalActiveReview(ctx, sqlc.SetAgentGoalActiveReviewParams{
+				ActiveReviewID: nullable(newID), UpdatedAt: now, ID: review.GoalID.String,
+			}); err != nil {
+				return err
+			}
+		}
 		return s.appendEvent(ctx, q, sqlc.InsertAgentTaskEventParams{
-			TaskID: review.TaskID, ReviewID: nullable(reviewID),
+			TaskID: review.TaskID, GoalID: review.GoalID, ReviewID: nullable(reviewID),
 			EventType: "review_escalated",
 			ActorType: actorTypeOrSystem(actor), ActorID: nullable(actor.ID),
 			Detail: detailJSON(map[string]any{"escalated_to_review_id": newID, "reason": reason}),
-		})
-	})
-}
-
-// decideReview is the shared path for approve / reject — both terminal-status
-// decisions that route the task to a fixed next state.
-func (s *TransitionService) decideReview(ctx context.Context, reviewID, decision, summary, feedback, nextTaskStatus string, actor Actor) error {
-	return s.withTx(ctx, func(q *sqlc.Queries) error {
-		review, err := q.GetAgentReview(ctx, reviewID)
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return ErrReviewNotFound
-			}
-			return err
-		}
-		if review.Status != ReviewRequested && review.Status != ReviewInProgress {
-			return ErrReviewClosed
-		}
-		if !review.TaskID.Valid {
-			return fmt.Errorf("decideReview: review %s has no task parent", reviewID)
-		}
-		taskID := review.TaskID.String
-		now := s.now()
-		if _, err := q.SetAgentReviewDecision(ctx, sqlc.SetAgentReviewDecisionParams{
-			Status: decision, Summary: summary, Feedback: feedback,
-			ResolvedAt: sql.NullString{String: now, Valid: true},
-			UpdatedAt:  now, ID: reviewID,
-		}); err != nil {
-			return err
-		}
-		if _, err := q.TransitionAgentTaskStatus(ctx, sqlc.TransitionAgentTaskStatusParams{
-			Status: nextTaskStatus, UpdatedAt: now, ID: taskID, Status_2: StatusReviewing,
-		}); err != nil {
-			return err
-		}
-		if nextTaskStatus == StatusDone {
-			_ = q.SetAgentTaskOutput(ctx, sqlc.SetAgentTaskOutputParams{
-				Output: "", CompletedAt: sql.NullString{String: now, Valid: true}, UpdatedAt: now, ID: taskID,
-			})
-		}
-		if err := q.SetAgentTaskActiveReview(ctx, sqlc.SetAgentTaskActiveReviewParams{
-			ActiveReviewID: sql.NullString{}, UpdatedAt: now, ID: taskID,
-		}); err != nil {
-			return err
-		}
-		return s.appendEvent(ctx, q, sqlc.InsertAgentTaskEventParams{
-			TaskID: nullable(taskID), ReviewID: nullable(reviewID),
-			EventType:  "review_" + decision,
-			FromStatus: nullable(StatusReviewing), ToStatus: nullable(nextTaskStatus),
-			ActorType: actorTypeOrSystem(actor), ActorID: nullable(actor.ID),
-			Detail: detailJSON(map[string]any{"summary": summary, "feedback": feedback}),
 		})
 	})
 }

--- a/internal/tasks/service_facade.go
+++ b/internal/tasks/service_facade.go
@@ -267,6 +267,102 @@ func (f *ServiceFacade) GetReview(ctx context.Context, reviewID string) (sqlc.Ag
 	return f.q.GetAgentReview(ctx, reviewID)
 }
 
+// ---------------------------------------------------------------------------
+// Goal facade
+// ---------------------------------------------------------------------------
+
+// CreateGoalInput is the request body for CreateGoal. OrgID/UserID/Title are
+// required; everything else carries safe defaults.
+type CreateGoalInput struct {
+	OrgID        string
+	UserID       string
+	AgentID      string
+	Title        string
+	Description  string
+	Priority     string
+	ReviewPolicy string
+	Context      string
+}
+
+// CreateGoal inserts an agent_goal row in 'draft'. The dispatcher's planner
+// scan will pick it up next tick when status=draft and an executor is
+// resolvable.
+func (f *ServiceFacade) CreateGoal(ctx context.Context, in CreateGoalInput) (sqlc.AgentGoal, error) {
+	if in.OrgID == "" || in.UserID == "" || in.Title == "" {
+		return sqlc.AgentGoal{}, fmt.Errorf("CreateGoal: org_id, user_id, and title are required")
+	}
+	priority := in.Priority
+	if priority == "" {
+		priority = "routine"
+	}
+	if priority != "routine" && priority != "urgent" {
+		return sqlc.AgentGoal{}, fmt.Errorf("CreateGoal: invalid priority %q", priority)
+	}
+	policy := in.ReviewPolicy
+	if policy == "" {
+		policy = ReviewPolicyNone
+	}
+	if in.Context == "" {
+		in.Context = "{}"
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	return f.q.CreateAgentGoal(ctx, sqlc.CreateAgentGoalParams{
+		ID:           uuid.NewString(),
+		OrgID:        in.OrgID,
+		UserID:       in.UserID,
+		AgentID:      nullable(in.AgentID),
+		Title:        in.Title,
+		Description:  in.Description,
+		Status:       GoalStatusDraft,
+		Priority:     priority,
+		ReviewPolicy: policy,
+		Context:      in.Context,
+		Output:       "{}",
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	})
+}
+
+// GetGoal returns one goal, enforcing the org boundary at the handler level
+// (the row carries org_id so handlers compare after fetch).
+func (f *ServiceFacade) GetGoal(ctx context.Context, goalID string) (sqlc.AgentGoal, error) {
+	g, err := f.q.GetAgentGoal(ctx, goalID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return sqlc.AgentGoal{}, ErrGoalNotFound
+		}
+		return sqlc.AgentGoal{}, err
+	}
+	return g, nil
+}
+
+// ListGoalsByOrg returns the org's goals, newest first.
+func (f *ServiceFacade) ListGoalsByOrg(ctx context.Context, orgID string, limit int64) ([]sqlc.AgentGoal, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	return f.q.ListAgentGoalsByOrg(ctx, sqlc.ListAgentGoalsByOrgParams{OrgID: orgID, Limit: limit, Offset: 0})
+}
+
+// ActivateGoal / CancelGoal are thin shims over TransitionService.
+func (f *ServiceFacade) ActivateGoal(ctx context.Context, goalID string, actor Actor) error {
+	return f.svc.ActivateGoal(ctx, goalID, actor)
+}
+
+func (f *ServiceFacade) CancelGoal(ctx context.Context, goalID, reason string, actor Actor) error {
+	return f.svc.CancelGoal(ctx, goalID, reason, actor)
+}
+
+// ListGoalTasks lists child tasks of a goal.
+func (f *ServiceFacade) ListGoalTasks(ctx context.Context, goalID string) ([]sqlc.AgentTask, error) {
+	return f.q.ListChildrenByGoal(ctx, nullable(goalID))
+}
+
+// ListGoalReviews lists reviews for a goal.
+func (f *ServiceFacade) ListGoalReviews(ctx context.Context, goalID string) ([]sqlc.AgentReview, error) {
+	return f.q.ListAgentReviewsByGoal(ctx, nullable(goalID))
+}
+
 func timeOrNull(t time.Time) sql.NullString {
 	if t.IsZero() {
 		return sql.NullString{}

--- a/internal/tasks/transition.go
+++ b/internal/tasks/transition.go
@@ -222,6 +222,7 @@ func (s *TransitionService) Claim(ctx context.Context, p ClaimParams) (ClaimResu
 		_, err = q.CreateAgentTaskRun(ctx, sqlc.CreateAgentTaskRunParams{
 			ID:              runID,
 			TaskID:          nullable(p.TaskID),
+			GoalID:          sql.NullString{},
 			OrgID:           task.OrgID,
 			UserID:          task.UserID,
 			AgentID:         task.AgentID,

--- a/pkg/db/sqlc/agent_review.sql.go
+++ b/pkg/db/sqlc/agent_review.sql.go
@@ -128,12 +128,102 @@ func (q *Queries) GetOpenReviewForTask(ctx context.Context, taskID sql.NullStrin
 	return i, err
 }
 
+const listAgentReviewsByGoal = `-- name: ListAgentReviewsByGoal :many
+SELECT id, task_id, goal_id, submitted_run_id, reviewer_run_id, reviewer_type, reviewer_user_id, escalated_from_review_id, status, summary, feedback, created_at, updated_at, resolved_at FROM agent_review WHERE goal_id = ? ORDER BY created_at DESC
+`
+
+func (q *Queries) ListAgentReviewsByGoal(ctx context.Context, goalID sql.NullString) ([]AgentReview, error) {
+	rows, err := q.db.QueryContext(ctx, listAgentReviewsByGoal, goalID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AgentReview{}
+	for rows.Next() {
+		var i AgentReview
+		if err := rows.Scan(
+			&i.ID,
+			&i.TaskID,
+			&i.GoalID,
+			&i.SubmittedRunID,
+			&i.ReviewerRunID,
+			&i.ReviewerType,
+			&i.ReviewerUserID,
+			&i.EscalatedFromReviewID,
+			&i.Status,
+			&i.Summary,
+			&i.Feedback,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.ResolvedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAgentReviewsByTask = `-- name: ListAgentReviewsByTask :many
 SELECT id, task_id, goal_id, submitted_run_id, reviewer_run_id, reviewer_type, reviewer_user_id, escalated_from_review_id, status, summary, feedback, created_at, updated_at, resolved_at FROM agent_review WHERE task_id = ? ORDER BY created_at DESC
 `
 
 func (q *Queries) ListAgentReviewsByTask(ctx context.Context, taskID sql.NullString) ([]AgentReview, error) {
 	rows, err := q.db.QueryContext(ctx, listAgentReviewsByTask, taskID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AgentReview{}
+	for rows.Next() {
+		var i AgentReview
+		if err := rows.Scan(
+			&i.ID,
+			&i.TaskID,
+			&i.GoalID,
+			&i.SubmittedRunID,
+			&i.ReviewerRunID,
+			&i.ReviewerType,
+			&i.ReviewerUserID,
+			&i.EscalatedFromReviewID,
+			&i.Status,
+			&i.Summary,
+			&i.Feedback,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.ResolvedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listOpenAgentReviewsForDispatch = `-- name: ListOpenAgentReviewsForDispatch :many
+SELECT id, task_id, goal_id, submitted_run_id, reviewer_run_id, reviewer_type, reviewer_user_id, escalated_from_review_id, status, summary, feedback, created_at, updated_at, resolved_at FROM agent_review
+WHERE status IN ('requested','in_progress')
+  AND reviewer_type = 'agent'
+  AND reviewer_run_id IS NULL
+ORDER BY created_at ASC
+LIMIT ?
+`
+
+// Reviews awaiting agent dispatch: open, reviewer_type='agent', reviewer_run_id unset.
+func (q *Queries) ListOpenAgentReviewsForDispatch(ctx context.Context, limit int64) ([]AgentReview, error) {
+	rows, err := q.db.QueryContext(ctx, listOpenAgentReviewsForDispatch, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -194,6 +284,25 @@ func (q *Queries) SetAgentReviewDecision(ctx context.Context, arg SetAgentReview
 		arg.UpdatedAt,
 		arg.ID,
 	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const setAgentReviewReviewerRun = `-- name: SetAgentReviewReviewerRun :execrows
+UPDATE agent_review SET reviewer_run_id = ?, status = 'in_progress', updated_at = ?
+WHERE id = ? AND reviewer_run_id IS NULL
+`
+
+type SetAgentReviewReviewerRunParams struct {
+	ReviewerRunID sql.NullString `json:"reviewer_run_id"`
+	UpdatedAt     string         `json:"updated_at"`
+	ID            string         `json:"id"`
+}
+
+func (q *Queries) SetAgentReviewReviewerRun(ctx context.Context, arg SetAgentReviewReviewerRunParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, setAgentReviewReviewerRun, arg.ReviewerRunID, arg.UpdatedAt, arg.ID)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/db/sqlc/agent_task_event.sql.go
+++ b/pkg/db/sqlc/agent_task_event.sql.go
@@ -13,16 +13,17 @@ import (
 const insertAgentTaskEvent = `-- name: InsertAgentTaskEvent :one
 
 INSERT INTO agent_task_event (
-    id, task_id, run_id, blocker_id, review_id, event_type, from_status, to_status,
+    id, task_id, goal_id, run_id, blocker_id, review_id, event_type, from_status, to_status,
     actor_type, actor_id, detail, created_at
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING id, task_id, goal_id, run_id, blocker_id, review_id, event_type, from_status, to_status, actor_type, actor_id, detail, created_at
 `
 
 type InsertAgentTaskEventParams struct {
 	ID         string         `json:"id"`
 	TaskID     sql.NullString `json:"task_id"`
+	GoalID     sql.NullString `json:"goal_id"`
 	RunID      sql.NullString `json:"run_id"`
 	BlockerID  sql.NullString `json:"blocker_id"`
 	ReviewID   sql.NullString `json:"review_id"`
@@ -40,6 +41,7 @@ func (q *Queries) InsertAgentTaskEvent(ctx context.Context, arg InsertAgentTaskE
 	row := q.db.QueryRowContext(ctx, insertAgentTaskEvent,
 		arg.ID,
 		arg.TaskID,
+		arg.GoalID,
 		arg.RunID,
 		arg.BlockerID,
 		arg.ReviewID,
@@ -76,6 +78,47 @@ SELECT id, task_id, goal_id, run_id, blocker_id, review_id, event_type, from_sta
 
 func (q *Queries) ListAgentTaskEvents(ctx context.Context, taskID sql.NullString) ([]AgentTaskEvent, error) {
 	rows, err := q.db.QueryContext(ctx, listAgentTaskEvents, taskID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AgentTaskEvent{}
+	for rows.Next() {
+		var i AgentTaskEvent
+		if err := rows.Scan(
+			&i.ID,
+			&i.TaskID,
+			&i.GoalID,
+			&i.RunID,
+			&i.BlockerID,
+			&i.ReviewID,
+			&i.EventType,
+			&i.FromStatus,
+			&i.ToStatus,
+			&i.ActorType,
+			&i.ActorID,
+			&i.Detail,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listAgentTaskEventsByGoal = `-- name: ListAgentTaskEventsByGoal :many
+SELECT id, task_id, goal_id, run_id, blocker_id, review_id, event_type, from_status, to_status, actor_type, actor_id, detail, created_at FROM agent_task_event WHERE goal_id = ? ORDER BY created_at ASC
+`
+
+func (q *Queries) ListAgentTaskEventsByGoal(ctx context.Context, goalID sql.NullString) ([]AgentTaskEvent, error) {
+	rows, err := q.db.QueryContext(ctx, listAgentTaskEventsByGoal, goalID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/db/sqlc/agent_task_run.sql.go
+++ b/pkg/db/sqlc/agent_task_run.sql.go
@@ -13,17 +13,18 @@ import (
 const createAgentTaskRun = `-- name: CreateAgentTaskRun :one
 
 INSERT INTO agent_task_run (
-    id, task_id, org_id, user_id, agent_id, executor_agent_id,
+    id, task_id, goal_id, org_id, user_id, agent_id, executor_agent_id,
     kind, attempt_no, status, session_id, input, lease_expires_at, worker_id,
     started_at, created_at, updated_at
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING id, task_id, goal_id, org_id, user_id, agent_id, executor_agent_id, kind, attempt_no, status, session_id, input, result, error, heartbeat_at, lease_expires_at, worker_id, started_at, finished_at, created_at, updated_at
 `
 
 type CreateAgentTaskRunParams struct {
 	ID              string         `json:"id"`
 	TaskID          sql.NullString `json:"task_id"`
+	GoalID          sql.NullString `json:"goal_id"`
 	OrgID           string         `json:"org_id"`
 	UserID          string         `json:"user_id"`
 	AgentID         sql.NullString `json:"agent_id"`
@@ -45,6 +46,7 @@ func (q *Queries) CreateAgentTaskRun(ctx context.Context, arg CreateAgentTaskRun
 	row := q.db.QueryRowContext(ctx, createAgentTaskRun,
 		arg.ID,
 		arg.TaskID,
+		arg.GoalID,
 		arg.OrgID,
 		arg.UserID,
 		arg.AgentID,
@@ -171,6 +173,47 @@ func (q *Queries) HeartbeatAgentTaskRun(ctx context.Context, arg HeartbeatAgentT
 		return 0, err
 	}
 	return result.RowsAffected()
+}
+
+const latestAgentTaskRunForGoal = `-- name: LatestAgentTaskRunForGoal :one
+SELECT id, task_id, goal_id, org_id, user_id, agent_id, executor_agent_id, kind, attempt_no, status, session_id, input, result, error, heartbeat_at, lease_expires_at, worker_id, started_at, finished_at, created_at, updated_at FROM agent_task_run
+WHERE goal_id = ? AND kind = ?
+ORDER BY attempt_no DESC
+LIMIT 1
+`
+
+type LatestAgentTaskRunForGoalParams struct {
+	GoalID sql.NullString `json:"goal_id"`
+	Kind   string         `json:"kind"`
+}
+
+func (q *Queries) LatestAgentTaskRunForGoal(ctx context.Context, arg LatestAgentTaskRunForGoalParams) (AgentTaskRun, error) {
+	row := q.db.QueryRowContext(ctx, latestAgentTaskRunForGoal, arg.GoalID, arg.Kind)
+	var i AgentTaskRun
+	err := row.Scan(
+		&i.ID,
+		&i.TaskID,
+		&i.GoalID,
+		&i.OrgID,
+		&i.UserID,
+		&i.AgentID,
+		&i.ExecutorAgentID,
+		&i.Kind,
+		&i.AttemptNo,
+		&i.Status,
+		&i.SessionID,
+		&i.Input,
+		&i.Result,
+		&i.Error,
+		&i.HeartbeatAt,
+		&i.LeaseExpiresAt,
+		&i.WorkerID,
+		&i.StartedAt,
+		&i.FinishedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
 }
 
 const latestAgentTaskRunForTask = `-- name: LatestAgentTaskRunForTask :one
@@ -319,6 +362,24 @@ func (q *Queries) ListStaleAgentTaskRuns(ctx context.Context, arg ListStaleAgent
 		return nil, err
 	}
 	return items, nil
+}
+
+const nextAttemptNoForGoal = `-- name: NextAttemptNoForGoal :one
+SELECT COALESCE(MAX(attempt_no), 0) + 1 AS next_attempt
+FROM agent_task_run
+WHERE goal_id = ? AND kind = ?
+`
+
+type NextAttemptNoForGoalParams struct {
+	GoalID sql.NullString `json:"goal_id"`
+	Kind   string         `json:"kind"`
+}
+
+func (q *Queries) NextAttemptNoForGoal(ctx context.Context, arg NextAttemptNoForGoalParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, nextAttemptNoForGoal, arg.GoalID, arg.Kind)
+	var next_attempt int64
+	err := row.Scan(&next_attempt)
+	return next_attempt, err
 }
 
 const nextAttemptNoForTask = `-- name: NextAttemptNoForTask :one

--- a/web/content/docs/changelog.mdx
+++ b/web/content/docs/changelog.mdx
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✨ Features
 
+- **Goals**: Flat `/api/goals` HTTP surface (create / list / get / activate /
+  cancel / list-tasks / list-reviews + review decisions). Dispatcher gains
+  `rollupGoals`, reviewer dispatch, planner dispatch, and synthesizer
+  dispatch tick steps. Goal-parented `agent_review` rows now flow through the
+  same approve / reject / request-changes / escalate path as task reviews,
+  driving goal status. With no real runner wired yet, reviewer / planner /
+  synthesizer runs are created queued and immediately fail with a
+  `protocol_error` event — the dispatch path is observable but waits on the
+  follow-up `agent.Pool` adapter PR before real execution.
+
 - **Tasks**: Flat `/api/tasks` HTTP surface. Tasks now live under the resolved
   org (header `X-Stella-Org-ID`, session fallback) instead of an agent path.
   Sub-resource POSTs replace the old action envelope:

--- a/web/content/docs/changelog.zh.mdx
+++ b/web/content/docs/changelog.zh.mdx
@@ -13,6 +13,14 @@ icon: History
 
 ### ✨ 功能
 
+- **目标**：扁平化 `/api/goals` HTTP 接口(create / list / get / activate /
+  cancel / list-tasks / list-reviews + 评审决策)。Dispatcher 新增
+  `rollupGoals`、reviewer 派发、planner 派发、synthesizer 派发 tick 步骤。
+  Goal-parented `agent_review` 行通过与任务评审相同的 approve / reject /
+  request-changes / escalate 路径驱动 goal 状态。当前 PR 还没接真实 runner,
+  reviewer / planner / synthesizer run 创建后会立即以 `protocol_error` 事
+  件失败 —— 派发路径已可观察,真实执行等后续 `agent.Pool` 适配器 PR。
+
 - **任务**：扁平化 `/api/tasks` HTTP 接口。任务在解析后的组织（`X-Stella-Org-ID`
   请求头，回退到会话默认组织）下管理，不再嵌套于 agent 路径下。子资源 POST 取代
   旧的 action 信封：`/api/tasks/{id}/cancel`、`/reopen`、`/deps`、

--- a/web/content/docs/development/goal-system.md
+++ b/web/content/docs/development/goal-system.md
@@ -1,0 +1,123 @@
+---
+title: Goal system
+description: Multi-step plans backed by tasks, with rollup, planner / synthesizer runs, and the review pipeline.
+---
+
+The goal system layers a planning + synthesis pass on top of the task system.
+A **goal** is a row in `agent_goal` that owns a set of child tasks. The
+dispatcher drives goals through draft → planning → running → (reviewing) →
+done via four kinds of runs and a pure rollup function.
+
+> Builds on the [Task system](./task-system).
+
+## Mental model
+
+| Concept              | Purpose                                                                                 |
+| -------------------- | --------------------------------------------------------------------------------------- |
+| `agent_goal`         | Container for a related set of tasks. Has a status + review policy + active review.     |
+| `agent_task.goal_id` | A task can belong to one goal (or be standalone).                                       |
+| `planner` run        | Generates the goal's draft child tasks. Emitted while the goal is in `draft`.           |
+| `synthesizer` run    | Aggregates child outputs into `agent_goal.output`. Emitted after required deps satisfy. |
+| `reviewer` run       | Same as task-side; can review goal-parented `agent_review` rows.                        |
+| `agent_review`       | One review row per parent (task or goal), XOR.                                          |
+
+## Goal lifecycle
+
+```
+draft ── planner ──▶ draft (children created)
+  │
+  └─ ActivateGoal ──▶ running ── rollup says all required done ─▶ done (policy=none)
+                                                              ├▶ reviewing (synthesizer + agent/human review)
+                                                              └▶ failed (required child failed)
+running ── required child blocked ──▶ blocked
+non-terminal ── CancelGoal ──▶ cancelled (cascade-cancels non-terminal children)
+```
+
+## Rollup
+
+`internal/tasks/goal_rollup.go` exposes a pure function:
+
+```go
+RollupGoal(goal, childCounts, hasOpenSynth) GoalNextState
+```
+
+The decision table for a `running` goal:
+
+| Required children | Review policy      | Verdict                                         |
+| ----------------- | ------------------ | ----------------------------------------------- |
+| any failed        | —                  | NextStatus=failed                               |
+| any blocked       | —                  | NextStatus=blocked                              |
+| any pending       | —                  | no-op                                           |
+| all done          | `none`             | NextStatus=done                                 |
+| all done          | `auto/agent/human` | SpawnSynthesizer=true (unless one is in flight) |
+
+Other goal statuses are no-ops at the rollup level — their transitions live
+in `ActivateGoal`, review decisions, etc.
+
+## Dispatcher tick
+
+Each tick now runs (after the task-side steps):
+
+1. `rollupGoals` — `RollupGoal` per non-terminal goal; applies the verdict.
+2. `scanAndDispatchReviewers` — for every open agent review (task- or
+   goal-parented) with no reviewer_run_id yet, create a `reviewer` run and
+   attach it via `SetAgentReviewReviewerRun`.
+3. `scanAndDispatchPlanners` — for every draft goal with no in-flight
+   planner, create one.
+4. `scanAndDispatchSynthesizers` — for every running goal whose rollup says
+   "spawn synthesizer," create one.
+
+### Noop runner state (current PR)
+
+The reviewer / planner / synthesizer runs are created in the database and
+**immediately failed** by `failGoalRunAsNoop` / `failReviewerRunAsNoop` with
+a `protocol_error` event. This keeps the dispatch path observable in events
+and runs without an `agent.Pool` adapter wired yet. A follow-up PR will
+replace the immediate-fail with real runner execution.
+
+What this means in practice:
+
+- `review_policy='agent'` reviews get a reviewer run + go in_progress, then
+  the run fails (visible in events as `dispatch_reviewer` + `protocol_error`).
+- Draft goals spawn one planner run per tick (each fails). The
+  unique-active partial indexes prevent overlap on a single tick.
+- Goals stuck waiting for the real runner are easy to spot: filter events
+  by `event_type='protocol_error' AND detail->>'reason' LIKE 'noop_%'`.
+
+## Goal review decisions
+
+`ApproveReview` / `RejectReview` / `RequestChanges` dispatch on parent type
+(`internal/tasks/review.go:decideAnyReview`):
+
+- Task parent: existing behavior (approve→done, reject→failed,
+  request_changes→ready or failed by retry budget).
+- Goal parent: approve→`goal.done`, reject→`goal.failed`,
+  request_changes→`goal.failed` (documented gap — no goal-level retry
+  budget; flagged for follow-up).
+
+`EscalateReview` repoints the matching `active_review_id` (task or goal) at
+the new human review row.
+
+## HTTP surface
+
+| Method | Path                                                                              | Purpose                                            |
+| ------ | --------------------------------------------------------------------------------- | -------------------------------------------------- |
+| POST   | `/api/goals`                                                                      | Create a goal (draft).                             |
+| GET    | `/api/goals`                                                                      | List goals in the resolved org.                    |
+| GET    | `/api/goals/{id}`                                                                 | Fetch one goal.                                    |
+| POST   | `/api/goals/{id}/activate`                                                        | Draft → running; promotes draft children to ready. |
+| POST   | `/api/goals/{id}/cancel`                                                          | Cascade-cancel non-terminal children.              |
+| GET    | `/api/goals/{id}/tasks`                                                           | List child tasks.                                  |
+| GET    | `/api/goals/{id}/reviews`                                                         | List goal reviews.                                 |
+| POST   | `/api/goals/{id}/reviews/{reviewID}/approve` (+reject, request-changes, escalate) | Decide on a goal review.                           |
+
+Org resolution mirrors `/api/tasks`: header `X-Stella-Org-ID` wins, falls
+back to the session default; cross-org access returns 404.
+
+## Pending follow-ups
+
+- Real `agent.Pool` ↔ runner adapter for reviewer / planner / synthesizer
+  runs. Until then, all three dispatch paths emit `protocol_error`.
+- Goal-side `request_changes` → synthesizer retry budget (currently
+  collapses to `failed`).
+- Web UI for goals.

--- a/web/content/docs/development/goal-system.zh.md
+++ b/web/content/docs/development/goal-system.zh.md
@@ -1,0 +1,119 @@
+---
+title: 目标系统
+description: 在任务系统之上叠加规划与综合,带 rollup、planner / synthesizer 运行和评审管道。
+---
+
+目标系统在任务系统之上叠加规划 + 综合 pass。**Goal** 是 `agent_goal` 中
+的一行,拥有一组子任务。dispatcher 通过四种 run 和一个纯 rollup 函数把
+goal 从 draft → planning → running → (reviewing) → done 推进。
+
+> 建立在[任务系统](./task-system)之上。
+
+## 心智模型
+
+| 概念                 | 用途                                                           |
+| -------------------- | -------------------------------------------------------------- |
+| `agent_goal`         | 一组相关任务的容器,有 status / review policy / active review。 |
+| `agent_task.goal_id` | 一个任务可以属于一个 goal(或独立)。                            |
+| `planner` run        | 生成 goal 的草稿子任务,在 goal 处于 `draft` 时下发。           |
+| `synthesizer` run    | 把子任务输出聚合到 `agent_goal.output`,在必需依赖满足后下发。  |
+| `reviewer` run       | 与任务侧相同;可评审 goal-parented `agent_review` 行。          |
+| `agent_review`       | 每个 parent(task 或 goal,XOR)一条评审行。                      |
+
+## Goal 生命周期
+
+```
+draft ── planner ──▶ draft(子任务被创建)
+  │
+  └─ ActivateGoal ──▶ running ── rollup 说必需子任务全部完成 ─▶ done(policy=none)
+                                                          ├▶ reviewing(synthesizer + agent/human 评审)
+                                                          └▶ failed(必需子任务失败)
+running ── 必需子任务 blocked ──▶ blocked
+非终止 ── CancelGoal ──▶ cancelled(级联取消非终止子任务)
+```
+
+## Rollup
+
+`internal/tasks/goal_rollup.go` 暴露一个纯函数:
+
+```go
+RollupGoal(goal, childCounts, hasOpenSynth) GoalNextState
+```
+
+对 `running` 状态的 goal,决策表:
+
+| 必需子任务   | review_policy      | 结论                                       |
+| ------------ | ------------------ | ------------------------------------------ |
+| 任一 failed  | —                  | NextStatus=failed                          |
+| 任一 blocked | —                  | NextStatus=blocked                         |
+| 任一 pending | —                  | 无操作                                     |
+| 全部 done    | `none`             | NextStatus=done                            |
+| 全部 done    | `auto/agent/human` | SpawnSynthesizer=true(除非已有 synth 在跑) |
+
+其他 goal 状态在 rollup 层是 no-op —— 它们的转换在 `ActivateGoal`、评审
+决策等位置完成。
+
+## Dispatcher tick
+
+每次 tick(在任务侧步骤之后)新增:
+
+1. `rollupGoals` —— 对每个非终止 goal 运行 `RollupGoal` 并应用结论。
+2. `scanAndDispatchReviewers` —— 对每条 reviewer_run_id 未设置的 open agent
+   评审(task- 或 goal-parented)创建一条 `reviewer` run,通过
+   `SetAgentReviewReviewerRun` 关联。
+3. `scanAndDispatchPlanners` —— 对每个 draft goal 创建一条 planner run。
+4. `scanAndDispatchSynthesizers` —— 对每个 rollup 说"该 synth"的 running
+   goal 创建一条 synthesizer run。
+
+### Noop runner 状态(当前 PR)
+
+reviewer / planner / synthesizer run 会被创建到数据库,然后立刻被
+`failGoalRunAsNoop` / `failReviewerRunAsNoop` 标 failed,并写一条
+`protocol_error` 事件。这样在没接 `agent.Pool` 适配器前,dispatch 路径
+就已经在 events / runs 里可观察。后续 PR 会用真实执行替换 immediate-fail。
+
+实际表现:
+
+- `review_policy='agent'` 的评审会拿到 reviewer run + 进入 in_progress,
+  然后 run 失败(在事件里看到 `dispatch_reviewer` + `protocol_error`)。
+- draft goal 每次 tick 会派一条 planner run(每条都失败);unique-active
+  partial index 保证同一 tick 内不会重复。
+- 通过 `event_type='protocol_error' AND detail->>'reason' LIKE 'noop_%'`
+  可以快速定位"还没接真 runner"的 goal。
+
+## Goal 评审决策
+
+`ApproveReview` / `RejectReview` / `RequestChanges` 按 parent 类型分发
+(`internal/tasks/review.go:decideAnyReview`):
+
+- task parent:原有行为(approve→done,reject→failed,
+  request_changes→ready 或按 retry 预算判 failed)。
+- goal parent:approve→`goal.done`,reject→`goal.failed`,
+  request_changes→`goal.failed`(已知缺口 —— goal 侧暂无重试预算,留待后
+  续)。
+
+`EscalateReview` 会把对应的 `active_review_id`(task 或 goal)指向新建
+的 human 评审行。
+
+## HTTP 接口
+
+| 方法 | 路径                                                                              | 用途                                          |
+| ---- | --------------------------------------------------------------------------------- | --------------------------------------------- |
+| POST | `/api/goals`                                                                      | 创建 goal(draft)。                            |
+| GET  | `/api/goals`                                                                      | 列出当前组织的 goal。                         |
+| GET  | `/api/goals/{id}`                                                                 | 获取单个 goal。                               |
+| POST | `/api/goals/{id}/activate`                                                        | Draft → running;把 draft 子任务提升到 ready。 |
+| POST | `/api/goals/{id}/cancel`                                                          | 级联取消非终止子任务。                        |
+| GET  | `/api/goals/{id}/tasks`                                                           | 列出子任务。                                  |
+| GET  | `/api/goals/{id}/reviews`                                                         | 列出 goal 评审。                              |
+| POST | `/api/goals/{id}/reviews/{reviewID}/approve`(reject / request-changes / escalate) | 对 goal 评审作决定。                          |
+
+组织作用域同 `/api/tasks`:`X-Stella-Org-ID` 优先,回退会话默认组织;跨
+组织访问返回 404。
+
+## 待办
+
+- 真正的 `agent.Pool` ↔ runner 适配器,覆盖 reviewer / planner / synthesizer。
+  在此之前所有三条 dispatch 路径都会 `protocol_error`。
+- Goal 侧 `request_changes` → synthesizer 重试预算(目前直接判 failed)。
+- Goal 的 Web UI。

--- a/web/content/docs/development/meta.json
+++ b/web/content/docs/development/meta.json
@@ -7,6 +7,7 @@
     "memory-internals",
     "session-compaction",
     "plugin-system",
-    "task-system"
+    "task-system",
+    "goal-system"
   ]
 }

--- a/web/content/docs/development/meta.zh.json
+++ b/web/content/docs/development/meta.zh.json
@@ -7,6 +7,7 @@
     "memory-internals",
     "session-compaction",
     "plugin-system",
-    "task-system"
+    "task-system",
+    "goal-system"
   ]
 }

--- a/web/content/docs/development/task-system.md
+++ b/web/content/docs/development/task-system.md
@@ -193,11 +193,12 @@ Slice 1 (MVP) ships:
 
 **Pending follow-ups (stacked PRs):**
 
-- Real agent.Pool ↔ RunnerFunc adapter (right now the runner is a noop
-  that explicitly fails so the path is observable in logs)
-- Reviewer dispatcher — `review_policy='agent'` currently parks the
-  task in `reviewing` correctly but no reviewer run is spawned yet.
-- Goal entity (`agent_goal` + planner / synthesizer + rollup).
+- Real agent.Pool ↔ RunnerFunc adapter for **all four** run kinds
+  (worker / reviewer / planner / synthesizer). The dispatcher now
+  creates each kind of run; the runners themselves are noop fallbacks
+  that immediately emit a `protocol_error` event.
+
+See [Goal system](./goal-system) for the goal-side details.
 
 ## HTTP surface
 

--- a/web/content/docs/development/task-system.zh.md
+++ b/web/content/docs/development/task-system.zh.md
@@ -175,11 +175,12 @@ Slice 1(MVP)已落地:
 
 **待办(后续 PR 跟进):**
 
-- 真正的 agent.Pool ↔ RunnerFunc 适配器(目前 runner 是 noop,显式失
-  败,以便日志里能看到)
-- Reviewer dispatcher — `review_policy='agent'` 当前能正确把任务停在
-  `reviewing`,但还没有 reviewer run 被派发。
-- Goal 实体(`agent_goal` + planner / synthesizer + rollup)。
+- 真正的 agent.Pool ↔ RunnerFunc 适配器,覆盖**全部四种** run kind
+  (worker / reviewer / planner / synthesizer)。dispatcher 现在会创建
+  四种 run;runner 本身是 noop fallback,立即写一条 `protocol_error`
+  事件。
+
+详细 goal 侧文档参见[目标系统](./goal-system)。
 
 ## HTTP 接口
 


### PR DESCRIPTION
## Summary

First stacked PR after #236. Exposes the task system v2 internal core over a flat `/api/tasks` HTTP surface, retires the old nested `/api/agents/{agentID}/tasks/...` routes, and migrates the CLI + web client so `main` stays usable end-to-end.

Branch off `main`. Plan: `~/.agents/sessions/stella/2026-05-28-task-system-v2-flat-api/plan.md`.

## What's in

- **Flat `/api/tasks` OpenAPI surface (Phase 1)** — list / create / get, cancel, reopen, readiness, events, runs, deps (+add/waive), blockers/resolve, and the human-review decisions (approve / reject / request-changes / escalate). v2 schemas mirror the sqlc shape. `mise run generate` is idempotent.
- **Real Go handlers (Phase 2)** — `internal/server/tasks.go` now wires every operation through `tasks.ServiceFacade`. Org resolved via `X-Stella-Org-ID` header with session fallback (D14); cross-org returns 404 to avoid leaking existence. Error envelopes per D4: `invalid_transition`, `dep_cycle`, `review_closed`, `dep_failure_requires_waiver`, `reopen_conflict` (body lists `downstream_ids`). `ServiceFacade` gains `ReopenTask`, `ListReviews`, `ApproveReview` / `RejectReview` / `RequestChanges` / `EscalateReview`, `GetBlocker`, `GetReview`. `internal/server/tasks_test.go` covers the happy paths plus the cycle 409, draft readiness, cancel, and the activate-on-create event trail.
- **CLI rewrite (Phase 3)** — `stella task list / get / create / cancel / reopen / readiness / events / deps / review {approve|reject|request-changes}` against the new client. The old `agent-id` positional is gone (`--agent` flag where needed); `update` / `delete` removed.
- **Web migration (Phase 4)** — six task panels (`TaskBoardPanel`, `TaskPanel`, `AgentSidebar`, `InspectorPanel`, `AutomationDashPanel`, `TaskNewPage`) use the regenerated client. v2 status strings (`draft` / `ready` / `reviewing`) replace v1 (`pending` / `review_requested`). Task detail panel fetches and surfaces `/readiness` so users can tell "waiting on a dep" apart from "blocked on a question."
- **Docs (Phase 5)** — changelog notes the flat API flip + CLI rewrite + web migration (en + zh). User guide swaps the v1 statuses for v2 and explains the readiness view. Dev doc adds the HTTP surface table and the error code table; "pending follow-ups" now points at the reviewer + goal dispatcher PR.

## Out of scope (next stacked PR)

- Reviewer dispatcher — `review_policy='agent'` reaches `reviewing` correctly but no reviewer run gets spawned.
- Goal HTTP endpoints, goal planner / synthesizer dispatcher, goal rollup.

## Test plan

- [x] `mise run format && mise run build && mise run test` green locally.
- [x] `mise run generate` idempotent (md5-verified).
- [x] `grep -rn "/api/agents/.*tasks" .` only matches changelog entries.
- [x] `internal/server/tasks_test.go` covers create / get / list / readiness / cancel / events / dep-cycle 409 / 404.
- [ ] CI Format + Test job.
- [ ] Manual smoke: `stella task create --title "..." --activate` against a running server; web Task panel still lists / opens / cancels.
