### PR TITLE
📝 docs: prepare v0.68.0 stable release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,7 @@ before:
     # happened to put on PATH, which is how release binaries ended up embedding
     # an SPA built on a Node version no pull request ever tests. mise.toml pins
     # the toolchain in one place; go through it.
-    - mise run build:embedded
+    - mise run build:embedded:release
 
 builds:
   - id: stellad

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,8 @@ RUN --mount=type=secret,id=github_token \
     --mount=type=cache,target=/root/.cache/go-build \
     if [ -f /run/secrets/github_token ]; then export GITHUB_TOKEN="$(cat /run/secrets/github_token)"; fi; \
     env -u GOOS -u GOARCH \
+      TARGET_GOOS=${TARGETOS} TARGET_GOARCH=${TARGETARCH} \
+      mise run build:embedded:runtimes && \
       TARGET_GOOS=${TARGETOS} TARGET_GOARCH=${TARGETARCH} STRIP=1 \
       mise run build
 

--- a/deploy/helm/stella/Chart.yaml
+++ b/deploy/helm/stella/Chart.yaml
@@ -3,12 +3,12 @@ name: stella
 description: Stella — a single-tenant, multi-user, multi-agent AI assistant platform. Single-replica production chart.
 type: application
 # Chart version — bump on chart changes, independent of the app version.
-version: 0.1.4
+version: 0.1.5
 # appVersion is metadata noting the Stella release this chart was developed
 # against. It is NOT the default image tag: the chart defaults image.tag to
 # "latest" (see stella.image / values.yaml) so a fresh install tracks the newest
 # published release. Pin image.tag or image.digest for reproducible deploys.
-appVersion: "v0.66.1"
+appVersion: "v0.68.0"
 home: https://stella.cherryin.com
 sources:
   - https://github.com/CherryHQ/stella

--- a/mise.toml
+++ b/mise.toml
@@ -157,6 +157,22 @@ description = "Generate code and build the SPA, i.e. everything the Go binary em
 # together lets mise resolve that dependency once instead of twice.
 depends = ["generate", "build:web"]
 
+[tasks."build:embedded:release"]
+description = "Prepare embedded assets for every GoReleaser platform"
+depends = ["build:embedded"]
+run = "mise run build:embedded:runtimes"
+
+[tasks."build:embedded:runtimes"]
+description = "Fetch embedded runtimes for every supported Unix target"
+run = """
+# GoReleaser cross-compiles all four supported Unix targets. Exact go:embed
+# names make a missing target asset a compile failure. Docker builds compile
+# every embed declaration too, so both release paths share this complete set.
+for target in darwin/amd64 darwin/arm64 linux/amd64 linux/arm64; do
+  TARGET_GOOS=${target%/*} TARGET_GOARCH=${target#*/} go run ./internal/tools/syncembeddedbinaries
+done
+"""
+
 # test depends on generate for the same reason build does: the embedded runtimes
 # must exist for the package to compile, and their absence used to turn the
 # embedded-tool tests into silent skips.

--- a/web/content/docs/changelog.mdx
+++ b/web/content/docs/changelog.mdx
@@ -11,85 +11,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### ✨ Added
-
-- `web` skill and `tool/lightpanda` manifest plugin: every public-web need is one skill, and the skill is a single bun program (`scripts/web.ts` plus its `scripts/lib/` modules), no Python. `bun scripts/web.ts search "<query>"` finds sources through the configured providers (Firecrawl, Parallel, Tavily, Exa, Jina, SearXNG, Brave, Keenable, each enabled by its API-key variable, usually a vault secret) and falls back to Exa's anonymous endpoint; `bun scripts/web.ts fetch <url>` reads one page as Markdown with Defuddle, renders it with Lightpanda when the plain HTML has no body, then asks Jina Reader; `bun scripts/web.ts site run <site/name> key=value` runs Tap-format site scripts through the Lightpanda nightly headless browser CLI. Nine scripts are bundled (X/Twitter posts and articles via FxEmbed, Exa search, GitHub, Hacker News, Reddit, Wikipedia, Bilibili); `web.ts site add <site/name | url | file>` installs any of the ~140 Tap catalog scripts, or your own, into `$XDG_CACHE_HOME/site-scripts/`, shared by all of a user's agents. Scripts need no login and no Chrome. The skill is on the default Agent template; add `web` to a custom template's `skills:` list to enable it.
+## [0.68.0] - 2026-09-05
 
 ### ⚠️ Breaking Changes
 
-- The builtin `web_search` and `web_fetch` tools are removed; the `web` skill (see Added) replaces them, and the `site-scripts` skill is renamed `web`. Search-provider keys are no longer read from the `stellad` environment: give them to an Agent as vault secrets (`EXA_API_KEY`, `BRAVE_SEARCH_API_KEY`, and peers), or rely on the keyless anonymous Exa fallback. Migration `90000000000037` deletes `tool_override` rows keyed by the two retired names. Update custom Skills, delegate presets, and Agent templates (`skills: [stella, web]`) before upgrading:
+- Managed Skill create/update tools now accept a complete Skill directory or ZIP archive instead of a single text file. Metadata comes from `SKILL.md`; updates replace the complete package, including removal of omitted resources. Update custom tool calls to pass a package path. ([#1259](https://github.com/CherryHQ/stella/pull/1259))
 
-  ```bash
-  grep -rn 'web_search\|web_fetch\|site-scripts' ~/.stella/skills ~/.stella/delegates ~/.stella/templates 2>/dev/null
-  ```
+### ✨ Features
 
-- Recally no longer captures articles server-side: read the page with the `web` skill and pass its file to `recally_article_save` as `content_path` (metadata from the fetch's JSON line fills `title`, `author`, `summary`, and `published_at`); a bare URL with no body is rejected, and a stored body under a few hundred characters is refused as a suspected stub. The tool still reports `content_chars` plus `content_preview`. `internal/webfetch` is deleted. The bundled `capture.py` script and the Tap-based Twitter and website feed workflows are gone; feed discovery now uses the `web` skill against the public FxEmbed API and page Markdown.
-- The built-in `tap-web` plugin is removed, along with its managed Tap, agent-browser, and Lightpanda binaries and the bundled `tap-web` skill. Web access now goes through the builtin `web_search` and `web_fetch` tools; Tap's site scripts survive as the new `site-scripts` skill (see Added). Migration `90000000000035` deletes the `tool/tap-web` plugin, state, and override rows; the sandbox no longer sets `AGENT_BROWSER_ENGINE`. Drop `tap-web` from any Agent template `skills:` list and rewrite Skills or delegate presets that shell out to `tap`.
+- Search and install remote MCP servers from the official registry, connect with OAuth, inspect server status and discovered tools, and control tool permissions across four scopes. The Web UI adds a marketplace and server details drawer. ([#1233](https://github.com/CherryHQ/stella/pull/1233), [#1234](https://github.com/CherryHQ/stella/pull/1234), [#1235](https://github.com/CherryHQ/stella/pull/1235), [#1236](https://github.com/CherryHQ/stella/pull/1236), [#1237](https://github.com/CherryHQ/stella/pull/1237))
+- Configure new or existing Feishu apps by QR code with the required permissions, events, and callbacks. Add `/doctor` for diagnosis from the current conversation. Existing-app configuration updates are additive. ([#1260](https://github.com/CherryHQ/stella/pull/1260))
+- Support complete managed Skill packages with scripts, references, and binary assets. Duplicate names now return an actionable conflict. ([#1259](https://github.com/CherryHQ/stella/pull/1259))
 
-- The hand-written `webfetch` tool is now the generated `web_fetch` tool, following the `<domain>_<action>` naming and schema rules. This is a clean rename with no alias; migration `90000000000034` deletes `tool_override` rows keyed by `webfetch`, restoring default visibility. Update custom Skills, delegate presets, and direct Code Mode calls before upgrading:
+### 🐛 Bug Fixes
 
-  ```bash
-  grep -rn 'webfetch' ~/.stella/skills ~/.stella/delegates .agents 2>/dev/null
-  ```
+- Improve Feishu forwarded-message and media handling, add per-group controls and a joined-group picker, and make streaming cards preserve the latest update, split long Markdown safely, and show reasoning/tool progress. Use `/abort` to stop a turn; reply cards no longer have a Cancel button. ([#1254](https://github.com/CherryHQ/stella/pull/1254))
+- Carry forward the v0.67.0 fixes that prepare embedded runtimes for cross-platform GoReleaser and Docker builds. ([#1248](https://github.com/CherryHQ/stella/pull/1248), [#1249](https://github.com/CherryHQ/stella/pull/1249))
 
-- All conversational Settings tools now use the `settings_` namespace so they are distinct from ordinary tools. This is a clean rename with no aliases; migration `90000000000032` deletes `tool_override` rows keyed by the retired names, restoring their default visibility. Update custom Skills, delegate presets, and any direct Code Mode calls before upgrading.
+### ♻️ Refactoring
 
-  | Old name                                                                                           | New name                                                                                                                                        |
-  | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-  | `agent_list`, `agent_get`, `agent_create`, `agent_update`, `agent_delete`                          | `settings_agent_list`, `settings_agent_get`, `settings_agent_create`, `settings_agent_update`, `settings_agent_delete`                          |
-  | `agent_tool_list`, `agent_tool_update`, `agent_tool_delete`                                        | `settings_agent_tool_list`, `settings_agent_tool_update`, `settings_agent_tool_delete`                                                          |
-  | `library_file_list`, `library_file_get`, `library_file_upload`, `library_file_delete`              | `settings_library_file_list`, `settings_library_file_get`, `settings_library_file_upload`, `settings_library_file_delete`                       |
-  | `skill_list`, `skill_get`, `skill_create`, `skill_update`, `skill_delete`                          | `settings_skill_list`, `settings_skill_get`, `settings_skill_create`, `settings_skill_update`, `settings_skill_delete`                          |
-  | `provider_list`, `provider_get`, `provider_create`, `provider_update`, `provider_delete`           | `settings_provider_list`, `settings_provider_get`, `settings_provider_create`, `settings_provider_update`, `settings_provider_delete`           |
-  | `default_model_get`, `default_model_update`                                                        | `settings_default_model_get`, `settings_default_model_update`                                                                                   |
-  | `embedding_setting_get`, `embedding_setting_update`                                                | `settings_embedding_setting_get`, `settings_embedding_setting_update`                                                                           |
-  | `plugin_list`, `plugin_enable`, `plugin_disable`                                                   | `settings_plugin_list`, `settings_plugin_enable`, `settings_plugin_disable`                                                                     |
-  | `mcp_server_list`, `mcp_server_get`, `mcp_server_create`, `mcp_server_update`, `mcp_server_delete` | `settings_mcp_server_list`, `settings_mcp_server_get`, `settings_mcp_server_create`, `settings_mcp_server_update`, `settings_mcp_server_delete` |
+- Separate non-channel provider and sandbox implementations from core through public package contracts and explicit startup composition. This does not add dynamic plugin loading. ([#1255](https://github.com/CherryHQ/stella/pull/1255))
+- Consolidate test harnesses around one testbed launcher and the main test and end-to-end commands. ([#1252](https://github.com/CherryHQ/stella/pull/1252))
 
-  Delegate family selectors changed too: rewrite `agent`, `agent_tool`, `provider`, `default_model`, `embedding_setting`, `plugin`, and `mcp` to their `settings_*` forms. The `library` and `skill` families now select only ordinary runtime tools; add `settings_library` or `settings_skill` when the preset intended Settings management.
+### 📝 Documentation
 
-  ```bash
-  # Scan project, shared, per-user, and per-Agent Skills and delegate presets.
-  STELLA_HOME="${STELLA_HOME:-$HOME/.stella}"
-  for root in . "$HOME/.agents" "$STELLA_HOME"; do
-    [ -d "$root" ] || continue
+- Require release notes, applicable metadata, and release-only fixes to be synced back to `main` before closing out a release. Restore the published 0.66.0, 0.66.1, and 0.67.0 records.
 
-    # Retired full action names in Skill prose and delegate presets.
-    find "$root" -type f \
-      \( -path '*/.agents/skills/*' -o -path '*/.agents/agent-skills/*' \
-         -o -path '*/.agents/db-skills/*' -o -path '*/.agents/delegates/*' \) \
-      -exec sh -c '
-        grep -nHE "\b(agent_(list|get|create|update|delete)|agent_tool_(list|update|delete)|library_file_(list|get|upload|delete)|skill_(list|get|create|update|delete)|provider_(list|get|create|update|delete)|default_model_(get|update)|embedding_setting_(get|update)|plugin_(list|enable|disable)|mcp_server_(list|get|create|update|delete))\b" "$@" || {
-          status=$?; [ "$status" -eq 1 ] || exit "$status"
-        }
-      ' sh {} +
+**Full Changelog**: [v0.67.0...v0.68.0](https://github.com/CherryHQ/stella/compare/v0.67.0...v0.68.0)
 
-    # Retired bare family selectors, limited to delegate YAML frontmatter.
-    find "$root" -type f -path '*/.agents/delegates/*.md' -exec awk '
-      FNR == 1 { frontmatter = ($0 == "---"); in_tools = 0; next }
-      frontmatter && $0 == "---" { frontmatter = 0; in_tools = 0; next }
-      !frontmatter { next }
-      /^[[:space:]]*(tools|excluded_tools):/ {
-        in_tools = 1; value = $0
-        sub(/^[^:]*:[[:space:]]*/, "", value)
-        if (has_retired(value)) print FILENAME ":" FNR ":" $0
-        next
-      }
-      in_tools && /^[[:space:]]*-[[:space:]]*/ {
-        if (has_retired($0)) print FILENAME ":" FNR ":" $0
-        next
-      }
-      in_tools { in_tools = 0 }
-      function has_retired(value, count, fields, i) {
-        gsub(/[^[:alnum:]_]+/, " ", value)
-        count = split(value, fields, /[[:space:]]+/)
-        for (i = 1; i <= count; i++)
-          if (fields[i] ~ /^(agent|agent_tool|library|library_file|skill|provider|default_model|embedding_setting|plugin|mcp|mcp_server)$/) return 1
-        return 0
-      }
-    ' {} +
-  done
-  ```
+## [0.67.0] - 2026-09-03
+
+### ⚠️ Breaking Changes
+
+- Public-web access is now the `web` skill: the built-in `web_search` and `web_fetch` tools, the `tap-web` plugin, and the `site-scripts` skill name are retired. Give search-provider keys to the Agent as vault secrets and update custom Skills, delegate presets, and Agent templates to use `web`. Migrations remove the retired tool and plugin override rows. ([#1229](https://github.com/CherryHQ/stella/pull/1229), [#1240](https://github.com/CherryHQ/stella/pull/1240))
+- Recally no longer captures articles server-side. Read a page with the `web` skill and pass its file as `content_path` to `recally_article_save`; bare URLs and suspected stub bodies are rejected. ([#1229](https://github.com/CherryHQ/stella/pull/1229))
+
+### ✨ Features
+
+- Add the Bun-powered `web` skill with provider-backed search, resilient Markdown fetch, Lightpanda site-script execution, and bundled public-site scripts. ([#1240](https://github.com/CherryHQ/stella/pull/1240))
+- Add generated, sandboxed public-web research tools. ([#1218](https://github.com/CherryHQ/stella/pull/1218))
+
+### 🐛 Bug Fixes
+
+- Make `PATCH /api/agents/{id}` a real partial update. ([#1226](https://github.com/CherryHQ/stella/pull/1226))
+- Repair GitHub reconnect scope parsing and clarify Agent Soul and personal/admin labels across the Web UI. ([#1224](https://github.com/CherryHQ/stella/pull/1224), [#1231](https://github.com/CherryHQ/stella/pull/1231))
+
+### ♻️ Refactoring
+
+- Reorganize internal packages, then remove the now-unnecessary single-implementer seams and plugin-owned scheduler. ([#1220](https://github.com/CherryHQ/stella/pull/1220), [#1227](https://github.com/CherryHQ/stella/pull/1227))
+
+**Full Changelog**: [v0.66.1...v0.67.0](https://github.com/CherryHQ/stella/compare/v0.66.1...v0.67.0)
+
+## [0.66.1] - 2026-09-01
+
+### 🐛 Bug Fixes
+
+- Rootless Docker sandboxes using a named `STELLA_HOME` volume now keep the `stellad` process identity, so principal-owned mise state and cache directories remain writable and built-in tool shims resolve correctly. ([#1214](https://github.com/CherryHQ/stella/pull/1214))
+
+**Full Changelog**: [v0.66.0...v0.66.1](https://github.com/CherryHQ/stella/compare/v0.66.0...v0.66.1)
+
+## [0.66.0] - 2026-09-01
 
 ### ⚠️ Breaking Changes
 
@@ -122,11 +103,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✨ Features
 
-- The built-in Agent with the reserved ID `stella` now enables conversational Settings tools by default. Migration `90000000000032` also enables them once for an existing built-in Stella Agent; an Agent manager can turn them off again after upgrading. Other Agents remain default-off.
+- Add Code Mode for context-efficient tool execution, with strict declarations and an in-process smoke gate covering every built-in tool. ([#1123](https://github.com/CherryHQ/stella/pull/1123), [#1184](https://github.com/CherryHQ/stella/pull/1184))
+- Group images now use canonical media routing, preserving consistent media ownership and delivery across channels. ([#1181](https://github.com/CherryHQ/stella/pull/1181))
+- Provider-level default models can be unified with per-agent model overrides. ([#1167](https://github.com/CherryHQ/stella/pull/1167))
+- Add a durable models.dev-backed provider/model catalog with sparse overrides, effective-model resolution, catalog sync, pricing, and searchable Provider and Agent model settings. ([#1210](https://github.com/CherryHQ/stella/pull/1210))
+- Tap Web now defaults to the Lightpanda browser runtime where supported. ([#1207](https://github.com/CherryHQ/stella/pull/1207))
+- Add owner-managed system settings tools for administrative configuration. ([#1189](https://github.com/CherryHQ/stella/pull/1189))
+- Release candidates now publish as GitHub prereleases with versioned Docker and sandbox images, without moving stable aliases or channels. ([#1201](https://github.com/CherryHQ/stella/pull/1201))
 
 ### 🐛 Bug Fixes
 
-- Rootless Docker sandboxes using a named `STELLA_HOME` volume now keep the `stellad` process identity, so principal-owned mise state and cache directories remain writable and built-in tool shims resolve correctly.
+- Share the React runtime with Base UI so the Web UI no longer loads duplicate React copies. ([#1212](https://github.com/CherryHQ/stella/pull/1212))
+- Tool visibility now fails closed when it cannot be resolved. ([#1175](https://github.com/CherryHQ/stella/pull/1175))
+- Harden Code Mode orchestration and file data flow across edge cases. ([#1169](https://github.com/CherryHQ/stella/pull/1169))
+- Repair the bundled runtime contract and harden every Xberg call site. ([#1149](https://github.com/CherryHQ/stella/pull/1149))
+- Repair system-test journeys that became flaky under Code Mode and per-media baselines. ([#1186](https://github.com/CherryHQ/stella/pull/1186))
+
+### ♻️ Refactoring
+
+- Session media now uses one baseline per media object, with owner purge, orphan sweeping, and tool cleanup. ([#1183](https://github.com/CherryHQ/stella/pull/1183))
+- Unify Library routing and profile UI, and route image inspection through `view_image`. ([#1164](https://github.com/CherryHQ/stella/pull/1164), [#1160](https://github.com/CherryHQ/stella/pull/1160))
+
+### 📡 Observability
+
+- Repair the agent-loop telemetry pipeline across traces, logs, metrics, and hooks. ([#1188](https://github.com/CherryHQ/stella/pull/1188))
+
+### 🔧 CI
+
+- Move script-bodied mise tasks into checked shell scripts, tighten web linting, and make release builds produce complete stamped binaries. ([#1153](https://github.com/CherryHQ/stella/pull/1153), [#1155](https://github.com/CherryHQ/stella/pull/1155), [#1158](https://github.com/CherryHQ/stella/pull/1158))
+
+### 🧪 Evaluation
+
+- Add the AWS Terminal-Bench 2.1 runner and a one-command report task for release evaluation and trend reporting. ([#1192](https://github.com/CherryHQ/stella/pull/1192), [#1206](https://github.com/CherryHQ/stella/pull/1206))
+
+### 📝 Documentation
+
+- Update tap-web examples and release/deployment documentation for the RC channel. ([#1174](https://github.com/CherryHQ/stella/pull/1174), [#1201](https://github.com/CherryHQ/stella/pull/1201))
+
+**Full Changelog**: [v0.65.0...v0.66.0](https://github.com/CherryHQ/stella/compare/v0.65.0...v0.66.0)
 
 ## [0.65.0] - 2026-08-25
 

--- a/web/content/docs/changelog.zh.mdx
+++ b/web/content/docs/changelog.zh.mdx
@@ -11,85 +11,66 @@ icon: History
 
 ## [Unreleased]
 
-### ✨ 新增
+## [0.68.0] - 2026-09-05
 
-- `web` skill 与 `tool/lightpanda` 清单插件：公开网页的所有需求收进一个 skill，且整个 skill 是一个 bun 程序（`scripts/web.ts` 及其 `scripts/lib/` 模块），没有 Python。`bun scripts/web.ts search "<query>"` 通过已配置的 provider（Firecrawl、Parallel、Tavily、Exa、Jina、SearXNG、Brave、Keenable，各由其 API key 变量启用，通常是密钥库 secret）查找来源，并回退到 Exa 匿名端点；`bun scripts/web.ts fetch <url>` 用 Defuddle 把页面读成 Markdown，纯 HTML 没有正文时改用 Lightpanda 渲染，再回退到 Jina Reader；`bun scripts/web.ts site run <site/name> key=value` 通过 Lightpanda nightly 无头浏览器 CLI 运行 Tap 格式的 site scripts。内置 9 个脚本（X/Twitter 帖子与文章经 FxEmbed、Exa 搜索、GitHub、Hacker News、Reddit、Wikipedia、Bilibili）；`web.ts site add <site/name | url | file>` 可把 Tap 目录约 140 个脚本或你自己写的脚本安装到 `$XDG_CACHE_HOME/site-scripts/`，同一用户的所有 agent 共享。脚本无需登录也不需要 Chrome。该 skill 已加入默认 Agent 模板，自定义模板需在 `skills:` 列表中加入 `web`。
+### ⚠️ Breaking Changes
+
+- 托管 Skill 创建和更新工具改为接收完整 Skill 目录或 ZIP 包，不再接收单个文本文件。元数据从 `SKILL.md` 读取；更新会替换整个包，删除新包中未包含的资源。自定义工具调用需改为传入包路径。([#1259](https://github.com/CherryHQ/stella/pull/1259))
+
+### ✨ Features
+
+- 支持从官方 registry 搜索安装远程 MCP server、通过 OAuth 连接、查看服务状态和发现的工具，并在四种作用域控制工具权限。Web UI 新增 marketplace 和服务详情抽屉。([#1233](https://github.com/CherryHQ/stella/pull/1233), [#1234](https://github.com/CherryHQ/stella/pull/1234), [#1235](https://github.com/CherryHQ/stella/pull/1235), [#1236](https://github.com/CherryHQ/stella/pull/1236), [#1237](https://github.com/CherryHQ/stella/pull/1237))
+- 支持扫码为新建或已有飞书应用配置必要权限、事件和回调，并新增 `/doctor`，根据当前对话诊断问题。已有应用的配置更新只追加缺失项。([#1260](https://github.com/CherryHQ/stella/pull/1260))
+- 托管 Skill 支持包含脚本、参考文档和二进制资源的完整包；名称重复时返回可操作的冲突提示。([#1259](https://github.com/CherryHQ/stella/pull/1259))
+
+### 🐛 Bug Fixes
+
+- 改进飞书合并转发和媒体处理，新增按群配置及已加入群选择器；流式卡片保留最新更新、安全拆分长 Markdown，并展示推理和工具进度。回复卡片移除 Cancel 按钮，使用 `/abort` 停止当前轮次。([#1254](https://github.com/CherryHQ/stella/pull/1254))
+- 带回 v0.67.0 的构建修复，为跨平台 GoReleaser 和 Docker 构建准备嵌入运行时。([#1248](https://github.com/CherryHQ/stella/pull/1248), [#1249](https://github.com/CherryHQ/stella/pull/1249))
+
+### ♻️ Refactoring
+
+- 通过公共包契约和显式启动组装，将非渠道 provider、sandbox 实现与核心分离；未新增动态插件加载。([#1255](https://github.com/CherryHQ/stella/pull/1255))
+- 将测试基础设施收敛到一个 testbed launcher，以及主测试和端到端测试命令。([#1252](https://github.com/CherryHQ/stella/pull/1252))
+
+### 📝 Documentation
+
+- 发布收尾前必须将发布说明、适用元数据及 release-only 修复同步回 `main`，并补齐已发布的 0.66.0、0.66.1、0.67.0 记录。
+
+**Full Changelog**: [v0.67.0...v0.68.0](https://github.com/CherryHQ/stella/compare/v0.67.0...v0.68.0)
+
+## [0.67.0] - 2026-09-03
 
 ### ⚠️ 破坏性变更
 
-- 内置 `web_search` 与 `web_fetch` 工具已移除，由 `web` skill（见新增）取代，`site-scripts` skill 更名为 `web`。搜索 provider 的 key 不再从 `stellad` 环境读取：以密钥库 secret 的形式交给 Agent（`EXA_API_KEY`、`BRAVE_SEARCH_API_KEY` 等），或依赖无需 key 的 Exa 匿名回退。迁移 `90000000000037` 删除以这两个旧名称为键的 `tool_override` 行。升级前请更新自定义 Skill、delegate preset 和 Agent 模板（`skills: [stella, web]`）：
+- 公开网页访问统一改为 `web` skill：内置 `web_search`、`web_fetch` 工具、`tap-web` 插件和 `site-scripts` skill 名称均已退休。请把搜索 provider 的 key 作为密钥库 secret 交给 Agent，并将自定义 Skill、delegate preset、Agent 模板改为使用 `web`。迁移会删除退休工具和插件的 override 行。([#1229](https://github.com/CherryHQ/stella/pull/1229), [#1240](https://github.com/CherryHQ/stella/pull/1240))
+- Recally 不再在服务端抓取文章。请用 `web` skill 读取页面，再将文件作为 `content_path` 传给 `recally_article_save`；裸 URL 与疑似摘要页正文会被拒绝。([#1229](https://github.com/CherryHQ/stella/pull/1229))
 
-  ```bash
-  grep -rn 'web_search\|web_fetch\|site-scripts' ~/.stella/skills ~/.stella/delegates ~/.stella/templates 2>/dev/null
-  ```
+### ✨ 功能
 
-- Recally 不再在服务端抓取文章：先用 `web` skill 读取页面，再把文件以 `content_path` 传给 `recally_article_save`（用 fetch 输出的 JSON 行中的元数据填充 `title`、`author`、`summary`、`published_at`）；只传裸 URL 不带正文会被拒绝，且低于几百字符的正文会因疑似摘要页被拒绝。工具仍返回 `content_chars` 与 `content_preview`。`internal/webfetch` 已删除。捆绑的 `capture.py` 脚本以及基于 Tap 的 Twitter / 网站 feed 工作流已移除；feed 发现改为用 `web` skill 访问公开的 FxEmbed API 和页面 Markdown。
-- 内置 `tap-web` 插件已移除，随之移除的还有它托管的 Tap、agent-browser、Lightpanda 二进制以及捆绑的 `tap-web` skill。网页访问改为使用内置的 `web_search` 与 `web_fetch` 工具；Tap 的 site scripts 以新的 `site-scripts` skill 形式保留（见「新增」）。迁移 `90000000000035` 会删除 `tool/tap-web` 的 plugin、state 与 override 行；沙箱不再设置 `AGENT_BROWSER_ENGINE`。请从 Agent 模板的 `skills:` 列表中去掉 `tap-web`，并改写调用 `tap` 的 Skill 或 delegate preset。
+- 新增基于 Bun 的 `web` skill，提供 provider 驱动的搜索、可靠的 Markdown 抓取、Lightpanda site-script 执行和内置公共站点脚本。([#1240](https://github.com/CherryHQ/stella/pull/1240))
+- 新增生成式、沙箱化的公开网页研究工具。([#1218](https://github.com/CherryHQ/stella/pull/1218))
 
-- 手写的 `webfetch` 工具现已改为生成式 `web_fetch`，遵循 `<domain>_<action>` 命名与 schema 规范。这是一次没有 alias 的干净改名；迁移 `90000000000034` 会删除以 `webfetch` 为键的 `tool_override` 行并恢复默认可见性。升级前请更新自定义 Skill、delegate preset 和直接调用 Code Mode 的代码：
+### 🐛 修复
 
-  ```bash
-  grep -rn 'webfetch' ~/.stella/skills ~/.stella/delegates .agents 2>/dev/null
-  ```
+- 让 `PATCH /api/agents/{id}` 成为真正的部分更新。([#1226](https://github.com/CherryHQ/stella/pull/1226))
+- 修复 GitHub 重连 scope 解析，并在 Web UI 中澄清 Agent Soul 与个人/管理员标签。([#1224](https://github.com/CherryHQ/stella/pull/1224), [#1231](https://github.com/CherryHQ/stella/pull/1231))
 
-- 所有对话式 Settings tools 现在统一使用 `settings_` 命名空间，与普通 tools 明确区分。这是一次没有 alias 的干净改名；迁移 `90000000000032` 会删除以旧名字为键的 `tool_override` 行，并恢复默认可见性。升级前请更新自定义 Skill、delegate preset 以及直接调用 Code Mode 的代码。
+### ♻️ 重构
 
-  | 旧名字                                                                                             | 新名字                                                                                                                                          |
-  | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-  | `agent_list`、`agent_get`、`agent_create`、`agent_update`、`agent_delete`                          | `settings_agent_list`、`settings_agent_get`、`settings_agent_create`、`settings_agent_update`、`settings_agent_delete`                          |
-  | `agent_tool_list`、`agent_tool_update`、`agent_tool_delete`                                        | `settings_agent_tool_list`、`settings_agent_tool_update`、`settings_agent_tool_delete`                                                          |
-  | `library_file_list`、`library_file_get`、`library_file_upload`、`library_file_delete`              | `settings_library_file_list`、`settings_library_file_get`、`settings_library_file_upload`、`settings_library_file_delete`                       |
-  | `skill_list`、`skill_get`、`skill_create`、`skill_update`、`skill_delete`                          | `settings_skill_list`、`settings_skill_get`、`settings_skill_create`、`settings_skill_update`、`settings_skill_delete`                          |
-  | `provider_list`、`provider_get`、`provider_create`、`provider_update`、`provider_delete`           | `settings_provider_list`、`settings_provider_get`、`settings_provider_create`、`settings_provider_update`、`settings_provider_delete`           |
-  | `default_model_get`、`default_model_update`                                                        | `settings_default_model_get`、`settings_default_model_update`                                                                                   |
-  | `embedding_setting_get`、`embedding_setting_update`                                                | `settings_embedding_setting_get`、`settings_embedding_setting_update`                                                                           |
-  | `plugin_list`、`plugin_enable`、`plugin_disable`                                                   | `settings_plugin_list`、`settings_plugin_enable`、`settings_plugin_disable`                                                                     |
-  | `mcp_server_list`、`mcp_server_get`、`mcp_server_create`、`mcp_server_update`、`mcp_server_delete` | `settings_mcp_server_list`、`settings_mcp_server_get`、`settings_mcp_server_create`、`settings_mcp_server_update`、`settings_mcp_server_delete` |
+- 重组 internal packages，并移除随之不再需要的单实现 seam 和插件自有 scheduler。([#1220](https://github.com/CherryHQ/stella/pull/1220), [#1227](https://github.com/CherryHQ/stella/pull/1227))
 
-  Delegate family selector 也需要更新：将 `agent`、`agent_tool`、`provider`、`default_model`、`embedding_setting`、`plugin`、`mcp` 改为对应的 `settings_*` family。`library` 与 `skill` 现在只选择普通运行时工具；原本用于 Settings 管理时，需要补充 `settings_library` 或 `settings_skill`。
+**完整变更记录**：[v0.66.1...v0.67.0](https://github.com/CherryHQ/stella/compare/v0.66.1...v0.67.0)
 
-  ```bash
-  # 扫描项目、共享、逐用户和逐 Agent 的 Skill 与 delegate preset。
-  STELLA_HOME="${STELLA_HOME:-$HOME/.stella}"
-  for root in . "$HOME/.agents" "$STELLA_HOME"; do
-    [ -d "$root" ] || continue
+## [0.66.1] - 2026-09-01
 
-    # Skill 正文和 delegate preset 中已退休的完整 action 名。
-    find "$root" -type f \
-      \( -path '*/.agents/skills/*' -o -path '*/.agents/agent-skills/*' \
-         -o -path '*/.agents/db-skills/*' -o -path '*/.agents/delegates/*' \) \
-      -exec sh -c '
-        grep -nHE "\b(agent_(list|get|create|update|delete)|agent_tool_(list|update|delete)|library_file_(list|get|upload|delete)|skill_(list|get|create|update|delete)|provider_(list|get|create|update|delete)|default_model_(get|update)|embedding_setting_(get|update)|plugin_(list|enable|disable)|mcp_server_(list|get|create|update|delete))\b" "$@" || {
-          status=$?; [ "$status" -eq 1 ] || exit "$status"
-        }
-      ' sh {} +
+### 🐛 修复
 
-    # 只在 delegate YAML frontmatter 中查找已退休的裸 family selector。
-    find "$root" -type f -path '*/.agents/delegates/*.md' -exec awk '
-      FNR == 1 { frontmatter = ($0 == "---"); in_tools = 0; next }
-      frontmatter && $0 == "---" { frontmatter = 0; in_tools = 0; next }
-      !frontmatter { next }
-      /^[[:space:]]*(tools|excluded_tools):/ {
-        in_tools = 1; value = $0
-        sub(/^[^:]*:[[:space:]]*/, "", value)
-        if (has_retired(value)) print FILENAME ":" FNR ":" $0
-        next
-      }
-      in_tools && /^[[:space:]]*-[[:space:]]*/ {
-        if (has_retired($0)) print FILENAME ":" FNR ":" $0
-        next
-      }
-      in_tools { in_tools = 0 }
-      function has_retired(value, count, fields, i) {
-        gsub(/[^[:alnum:]_]+/, " ", value)
-        count = split(value, fields, /[[:space:]]+/)
-        for (i = 1; i <= count; i++)
-          if (fields[i] ~ /^(agent|agent_tool|library|library_file|skill|provider|default_model|embedding_setting|plugin|mcp|mcp_server)$/) return 1
-        return 0
-      }
-    ' {} +
-  done
-  ```
+- 使用 named `STELLA_HOME` volume 的 rootless Docker 沙箱现在会保持 `stellad` 的进程身份，确保 principal 所有的 mise state 与 cache 目录可写，内置工具 shim 也能正确解析。([#1214](https://github.com/CherryHQ/stella/pull/1214))
+
+**完整变更记录**：[v0.66.0...v0.66.1](https://github.com/CherryHQ/stella/compare/v0.66.0...v0.66.1)
+
+## [0.66.0] - 2026-09-01
 
 ### ⚠️ 破坏性变更
 
@@ -122,11 +103,44 @@ icon: History
 
 ### ✨ 功能
 
-- 保留 ID 为 `stella` 的内置 Agent 现在默认开启对话式 Settings tools。迁移 `90000000000032` 也会为已有的内置 Stella Agent 强制开启一次；升级后 Agent 管理者仍可再次关闭。其他 Agent 继续默认关闭。
+- 新增 Code Mode，以更高效地执行工具调用，并通过进程内 smoke gate 覆盖每个内置工具。([#1123](https://github.com/CherryHQ/stella/pull/1123), [#1184](https://github.com/CherryHQ/stella/pull/1184))
+- 群聊图片现在通过统一的 canonical media 路由，确保不同 channel 的媒体归属和投递行为一致。([#1181](https://github.com/CherryHQ/stella/pull/1181))
+- 统一 provider 级默认模型与 Agent 级模型覆盖配置。([#1167](https://github.com/CherryHQ/stella/pull/1167))
+- 新增基于 models.dev 的持久化 provider/model catalog，支持稀疏覆盖、有效模型解析、catalog 同步、定价，以及可搜索的 Provider 和 Agent 模型设置。([#1210](https://github.com/CherryHQ/stella/pull/1210))
+- Tap Web 现在会在支持的环境中默认使用 Lightpanda 浏览器 runtime。([#1207](https://github.com/CherryHQ/stella/pull/1207))
+- 新增由 owner 管理的系统设置工具，用于管理配置。([#1189](https://github.com/CherryHQ/stella/pull/1189))
+- Release Candidate 现在以 GitHub prerelease 和带完整版本号的 Docker、sandbox 镜像发布，不会移动 Stable 别名或渠道。([#1201](https://github.com/CherryHQ/stella/pull/1201))
 
 ### 🐛 修复
 
-- 使用 named `STELLA_HOME` volume 的 rootless Docker 沙箱现在会保持 `stellad` 的进程身份，确保 principal 所有的 mise state 与 cache 目录可写，内置工具 shim 也能正确解析。
+- 让 Web UI 与 Base UI 共享 React runtime，避免重复加载 React 副本。([#1212](https://github.com/CherryHQ/stella/pull/1212))
+- 工具可见性无法解析时现在默认拒绝，而不是放行。([#1175](https://github.com/CherryHQ/stella/pull/1175))
+- 加固 Code Mode 编排和文件数据流在边界场景下的行为。([#1169](https://github.com/CherryHQ/stella/pull/1169))
+- 修复内置 runtime 契约，并加固所有 Xberg 调用点。([#1149](https://github.com/CherryHQ/stella/pull/1149))
+- 修复 Code Mode 和按媒体基线变更后出现问题的 system-test journey。([#1186](https://github.com/CherryHQ/stella/pull/1186))
+
+### ♻️ 重构
+
+- session media 现在每个媒体对象使用一个基线，并增加 owner purge、孤儿清理和工具清理。([#1183](https://github.com/CherryHQ/stella/pull/1183))
+- 统一 Library 路由与 profile UI，并让图片检查通过 `view_image` 路由。([#1164](https://github.com/CherryHQ/stella/pull/1164), [#1160](https://github.com/CherryHQ/stella/pull/1160))
+
+### 📡 可观测性
+
+- 修复 agent loop 在 trace、log、metric 和 hook 之间的 telemetry pipeline。([#1188](https://github.com/CherryHQ/stella/pull/1188))
+
+### 🔧 CI
+
+- 将脚本型 mise task 移入受检查的 shell 脚本，收紧 web lint，并让 release build 产出完整且带版本信息的二进制文件。([#1153](https://github.com/CherryHQ/stella/pull/1153), [#1155](https://github.com/CherryHQ/stella/pull/1155), [#1158](https://github.com/CherryHQ/stella/pull/1158))
+
+### 🧪 评估
+
+- 新增 AWS Terminal-Bench 2.1 runner 与一条命令生成报告的 task，用于发布评估和趋势追踪。([#1192](https://github.com/CherryHQ/stella/pull/1192), [#1206](https://github.com/CherryHQ/stella/pull/1206))
+
+### 📝 文档
+
+- 更新 tap-web 示例，并补充 RC 渠道的发布与部署文档。([#1174](https://github.com/CherryHQ/stella/pull/1174), [#1201](https://github.com/CherryHQ/stella/pull/1201))
+
+**完整变更记录**：[v0.65.0...v0.66.0](https://github.com/CherryHQ/stella/compare/v0.65.0...v0.66.0)
 
 ## [0.65.0] - 2026-08-25
 

--- a/web/content/docs/development/rules/release.md
+++ b/web/content/docs/development/rules/release.md
@@ -123,11 +123,12 @@ commit that is not reachable from that branch.
     ```
 12. CI triggers `.github/workflows/release.yml`. It verifies the exact tagged
     commit and the matching maintained branch before publication starts.
-13. After CI succeeds and the GitHub Release is visible, open a sync-back PR
-    from `release/vX.Y` to `main` when the release branch contains commits not
-    already present on `main`. For an RC, keep the milestone open until the
-    final stable release.
-14. After the stable release only, close the version milestone:
+13. After all release CI jobs succeed and the GitHub Release is visible, the
+    release owner must complete [Sync back to main](#sync-back-to-main). Both RC
+    and stable releases require this step. Opening a PR alone does not complete
+    the release.
+14. After the stable release and sync-back are complete, close the version
+    milestone. For an RC, keep it open until the final stable release:
     ```bash
     MILESTONE_NUMBER=$(gh api 'repos/CherryHQ/stella/milestones?state=open' \
       --jq '.[] | select(.title == "vX.Y.Z") | .number')
@@ -138,6 +139,48 @@ commit that is not reachable from that branch.
 
 The version milestone is the durable release record. Do not create a duplicate
 `release:vX.Y.Z` label.
+
+## Sync back to main
+
+The release owner owns sync-back through merge. Publication alone does not
+complete a release; do not defer changelogs or release-only fixes to the next
+version.
+
+1. Fetch the latest `main` and release branch, and use the published tag as the
+   fixed source for the sync. Review its changes against `main`, including
+   release preparation and any fixes made while getting publication to pass.
+   Commit ancestry alone does not prove that content is missing or present:
+   earlier syncs and backports may have been squashed or cherry-picked.
+2. Open a PR targeting `main`. A direct release-branch PR is suitable only when
+   its full diff contains the intended changes. Otherwise, create a short-lived
+   `sync/vX.Y.Z-to-main` branch from current `main` and port the relevant changes
+   from the tag. Follow `project-tracker.md` and the PR template.
+3. Account for every part of the release:
+   - Restore missing published version sections in both changelogs. Preserve
+     later `main` work in `Unreleased`; remove only entries confirmed to belong
+     to the published release. Never replace the whole file with the release
+     copy or defer the version boundary to a future release.
+   - Sync `web/package.json` and applicable stable Helm metadata without
+     downgrading newer versions on `main` or overwriting newer chart changes.
+     RC syncs must not change stable Helm metadata.
+   - Port release-only code, build, and documentation fixes. For each fix,
+     identify its main commit or linked PR, or explain why it does not apply.
+4. Resolve conflicts on the sync branch while preserving later `main` changes.
+   Run the checks required for the changes, obtain review, and merge the PR.
+   If a fix uses a separate PR, that PR must also be merged before closing out
+   the release. Never merge all of `main` into the maintained release branch
+   to resolve sync-back conflicts.
+5. Verify the merged `main` contains both language versions of the release
+   notes, applicable metadata, and all applicable release-only fixes. Record
+   the published tag and merged sync/fix PR links in the release preparation
+   PR. If everything was already present, record the supporting main commits
+   there instead of creating an empty PR.
+
+If sync-back fails, conflicts, or its PR is closed without merging, the release
+remains published with sync-back incomplete. Keep the milestone open, record the
+remaining work in the release preparation PR, and finish it before closing out
+the release. Do not move or recreate the published tag to repair a main-only
+sync problem.
 
 ## Update Changelog
 

--- a/web/content/docs/development/rules/release.zh.md
+++ b/web/content/docs/development/rules/release.zh.md
@@ -32,41 +32,48 @@ RC 从维护中的 `release/vX.Y` 分支切出，依次发布 `rc.1`、`rc.2`，
 ## 发布流程
 
 1. 选择发布 tag `vX.Y.Z` 或 `vX.Y.Z-rc.N`；Web package 版本为去掉开头 `v` 的相同版本。
-2. 更新 `web/package.json`，确保 `.version` 与 API/server 发布版本一致：
+2. 新 minor 从选定的 `main` 提交切出 `release/vX.Y`；已有 patch 线只接收选定的 backport，不合入整个 `main`。从最新维护分支创建短期准备分支，发布元数据通过 PR 合入维护分支。
+3. 更新 `web/package.json`，确保 `.version` 与 API/server 发布版本一致：
    ```bash
    VERSION=X.Y.Z
    tmp=$(mktemp)
    jq --arg version "$VERSION" '.version = $version' web/package.json > "$tmp" && mv "$tmp" web/package.json
    test "$(jq -r '.version' web/package.json)" = "$VERSION"
    ```
-3. Stable 发布时，更新 `deploy/helm/stella/Chart.yaml` 中的 Helm chart 元数据：
+4. Stable 发布时，更新 `deploy/helm/stella/Chart.yaml` 中的 Helm chart 元数据：
    - 将 `appVersion` 设为 `"vX.Y.Z"`，记录 chart 同期交付的应用版本。默认 `image.tag` 为 `latest`，CI 会在每个稳定版本发布它，因此全新安装会直接使用该版本；`appVersion` 只负责保持元数据准确。
    - 如果 chart 自上次发布后发生变化，递增 chart 自身独立的 SemVer `version`。
 
    RC 不更新或发布稳定 Helm chart。RC 部署必须显式将 `image.tag` 固定为完整的候选版本 tag。
 
-4. 更新 `web/content/docs/changelog.mdx` 和 `web/content/docs/changelog.zh.mdx`。
-5. 提交：`📝 docs: Update CHANGELOG for vX.Y.Z`，包含两份 changelog 和 `web/package.json`；Stable 发布还包含 `deploy/helm/stella/Chart.yaml`。
-6. 确认提交成功且工作区干净：
+5. 更新 `web/content/docs/changelog.mdx` 和 `web/content/docs/changelog.zh.mdx`。
+6. 提交：`📝 docs: Update CHANGELOG for vX.Y.Z`，包含两份 changelog 和 `web/package.json`；Stable 发布还包含 `deploy/helm/stella/Chart.yaml`。
+7. 运行下文的 `mise run release:validate` 完整发布前门禁，确认发布提交是 `HEAD` 且工作区干净：
    ```bash
    git status --short
    git log --oneline -1
    ```
    如果发布提交不是 `HEAD`，立即停止；提交存在前绝不打 tag。
-7. 确认版本 Milestone 包含准确的发布范围，且没有未关闭的 Issue。存在未关闭 Issue 时停止，不要打 tag：
+8. 确认版本 Milestone 包含准确的发布范围，且没有未关闭的 Issue。存在未关闭 Issue 时停止，不要打 tag：
    ```bash
    gh issue list --repo CherryHQ/stella --milestone vX.Y.Z --state open
    gh issue list --repo CherryHQ/stella --milestone vX.Y.Z --state all
    ```
-8. 为发布提交打 tag，并验证 tag 指向 `HEAD`：
-   ```bash
-   TAG=vX.Y.Z # 或 vX.Y.Z-rc.N
-   git tag "$TAG"
-   test "$(git rev-parse "$TAG")" = "$(git rev-parse HEAD)"
-   ```
-9. 显式推送维护分支与新 tag：`git push origin "$RELEASE_BRANCH" vX.Y.Z`。
-10. CI 触发 `.github/workflows/release.yml`。其中的 validation job 会先验证 tag 指向的确切提交，之后 GoReleaser 和 Docker 发布 job 才能开始。
-11. Stable 发布的 CI 成功且 GitHub Release 可见后，关闭版本 Milestone。RC 发布保持 Milestone 开放，直到最终 Stable 发布：
+9. 推送准备分支，向 `release/vX.Y` 创建 PR，等待必要检查通过后合并。GitHub 不会因合入非默认分支而自动关闭关联 Issue，需显式关闭发布 Issue，并重新确认 Milestone 没有未完成范围。
+10. 获取已合并的维护分支，为远端最新提交打 tag 后推送：
+    ```bash
+    RELEASE_BRANCH=release/vX.Y
+    git fetch origin --prune
+    git switch "$RELEASE_BRANCH"
+    git reset --hard "origin/$RELEASE_BRANCH"
+    TAG=vX.Y.Z # 或 vX.Y.Z-rc.N
+    git tag "$TAG"
+    test "$(git rev-parse "$TAG")" = "$(git rev-parse origin/$RELEASE_BRANCH)"
+    git push origin "$TAG"
+    ```
+11. CI 触发 `.github/workflows/release.yml`，先验证 tag 的确切提交属于对应维护分支，再运行验证与发布任务。
+12. 所有发布 CI 任务成功且 GitHub Release 可见后，发布负责人必须完成[同步回 main](#同步回-main)。RC 和 Stable 都必须执行；只创建 PR 不算发布完成。
+13. Stable 发布及回流完成后，关闭版本 Milestone。RC 保持 Milestone 开放，直到最终 Stable 发布：
     ```bash
     MILESTONE_NUMBER=$(gh api 'repos/CherryHQ/stella/milestones?state=open' \
       --jq '.[] | select(.title == "vX.Y.Z") | .number')
@@ -76,6 +83,36 @@ RC 从维护中的 `release/vX.Y` 分支切出，依次发布 `rc.1`、`rc.2`，
     ```
 
 版本 Milestone 是持久的发布记录，不要再创建重复的 `release:vX.Y.Z` label。
+
+## 同步回 main
+
+发布负责人负责跟进回流直到合并。产物发布成功后，仍需完成回流；不能将 changelog
+或 release-only 修复推迟到下一个版本。
+
+1. 获取最新 `main` 和 release 分支，以已发布 tag 为固定来源，核对相对 `main`
+   的变更，包括发布准备及为修通发布而新增的修复。此前回流或 backport 可能使用
+   squash 或 cherry-pick，不能仅凭提交祖先关系判断内容是否已经存在。
+2. 创建以 `main` 为目标的 PR。只有完整 diff 都是预期改动时，才直接使用 release
+   分支；否则从当前 `main` 创建短期 `sync/vX.Y.Z-to-main` 分支，移植 tag 中的
+   相关改动。遵循 `project-tracker.zh.md` 和 PR 模板。
+3. 逐项核对发布内容：
+   - 补齐中英文 changelog 缺失的已发布版本章节。保留 `main` 后续工作的
+     `Unreleased` 条目，只移除确认属于已发布版本的条目。禁止整文件覆盖，也不能
+     把版本边界整理推迟到未来发布。
+   - 同步 `web/package.json` 和适用的 Stable Helm 元数据，但不能降低 `main`
+     上更新的版本或覆盖后续 chart 改动。RC 回流不能更改稳定 Helm 元数据。
+   - 移植 release-only 的代码、构建和文档修复。每项修复都要注明对应的 main
+     提交或关联 PR，不适用的则解释原因。
+4. 在同步分支解决冲突，保留 `main` 后续改动。按变更范围完成必要检查，经审阅后
+   合并 PR。单独提交的修复 PR 也必须合并，才能完成发布收尾。禁止为解决回流冲突
+   而把整个 `main` 合入维护中的 release 分支。
+5. 核实合并后的 `main` 已包含双语发布记录、适用元数据及全部适用的 release-only
+   修复。在发布准备 PR 中记录已发布 tag、已合并的同步和修复 PR 链接。如果内容
+   已全部存在，记录对应 main 提交作为依据，不创建空 PR。
+
+回流失败、存在冲突或 PR 未合并就被关闭时，状态为“已发布，回流未完成”。保持
+Milestone 开放，在发布准备 PR 中记录剩余工作，完成后再收尾。不能为修复仅涉及
+main 的回流问题而移动或重建已发布 tag。
 
 ## 更新 Changelog
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.66.1",
+  "version": "0.68.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What

Prepare v0.68.0 stable from main commit `5d621fc736c7053073e4de42b447cf1d8c382eed`, including remote MCP management and marketplace, Feishu improvements, and complete managed Skill packages.

## Why

These features belong to a new minor line. Previous releases left published changelogs and cross-platform build fixes off main; this release restores those records and makes merged sync-back part of release completion.

## How

- Set the Web version and Helm appVersion to 0.68.0 / v0.68.0; restore chart version 0.1.5 from v0.67.0 because the chart itself has no subsequent changes.
- Add bilingual v0.68.0 notes and restore v0.66.0, v0.66.1, and v0.67.0 sections from the published tag. Preserve the earlier published history.
- Port #1248 and #1249, preparing all four Unix embedded runtime targets for GoReleaser and Docker builds.
- Require reviewed, merged sync-back of release records, applicable metadata, and release-only fixes before milestone closure. Align the Chinese preparation flow with the maintained-branch PR process.
- Follow publication with a separate sync-back PR to main. Keep the milestone open until that PR is merged and verified.

## Test

- `mise run release:validate`: passed on macOS arm64. This ran format, build, all Go tests, 37 Web test files / 344 tests, the subprocess system suite (92.857s), GoReleaser configuration checks, and a four-platform release snapshot.
- Snapshot built Linux/macOS amd64/arm64 archives plus Linux deb/rpm packages; host archive contains stellad.
- `git diff --check`: passed.
- Verified bilingual v0.68.0/v0.67.0/v0.66.1/v0.66.0 sections, no duplicate version headings, package version 0.68.0, and published history preserved byte-for-byte from v0.67.0.
- Existing modernize edit-conflict and frontend unknown-return warnings remain; no lint errors.
- Hosted Format, Test (race detection and coverage), and Windows compile-only checks passed: https://github.com/CherryHQ/stella/actions/runs/33937623437 . Tag publication failed in both system-test lanes: `tool_smoke_canary` generated an invalid ZIP under dash because it used bash-specific hexadecimal printf escapes. Run: https://github.com/CherryHQ/stella/actions/runs/33938226261 . The tag remains at `cb087eb6d48f9d85d326db9c34b740c9086d3059`; only the sandbox image was published. GoReleaser and main Docker publication were skipped. This incomplete attempt was superseded by the successful v0.68.1 publication. Release records and fixes were synced to main by #1264, verified at `0dd22fdab8712128437bd07681d99de1b32b3f15`.

No new Terminal-Bench run is included in this release preparation. The release uses the documented risk-based gate and makes no agent-performance improvement claim. Feishu live-tenant rendering/media and managed Skill binary resources are not covered by Terminal-Bench; component PRs record their focused tests, and live Feishu E2E was not run. Current full local and release CI gates validate this candidate's build and deterministic behavior.

## Refs

No issue: release preparation and recovery of missing release bookkeeping and previously merged build fixes.

Release milestone: https://github.com/CherryHQ/stella/milestone/29

Includes #1233, #1234, #1235, #1236, #1237, #1252, #1254, #1255, #1259, #1260. Carries forward #1248 and #1249. Refs #1232, #1196, #1251, #1253, #1257, #1258; #1191 remains a broader design issue.

## Checklist

- [x] No new issue: release preparation and existing release fixes, as described above.
- [x] No new application behavior is introduced by preparation; existing build fixes are validated by the release snapshot and tag CI.
- [x] English and Chinese release notes and release workflow documentation are updated.
- [x] I ran `mise run format && mise run build && mise run test` through `mise run release:validate`.
- [x] No new agent-performance claim; the risk-based eval decision and evidence limitations are stated above.
- [x] Feishu live rendering/media and Skill binary resources are outside Terminal-Bench coverage; component PR tests and the live-E2E gap are stated above.
- [x] No prior evaluation is changed or claimed to validate this new candidate.
