### PR TITLE
🐛 fix(release): prepare v0.68.1 with portable system canary

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -94,13 +94,12 @@ jobs:
       - name: Build web assets
         run: mise run build:web
 
-      # `test:coverage:race` is `go test` only, so until this step existed the
-      # frontend suite was gated at tag time and nowhere else — a PR could merge
-      # green with every vitest guard failing.
+      # The race/coverage task covers Go and process tests; run frontend tests
+      # separately so a PR cannot merge with failing Web guards.
       - name: Run frontend tests
         run: mise run test:web
 
-      - name: Run tests with race detection and coverage
+      - name: Run package race/coverage and subprocess system tests
         run: mise run test:coverage:race
         env:
           STELLA_TEST_REQUIRE_BWRAP: "1"
@@ -108,6 +107,15 @@ jobs:
           # generated above instead of allowing real extraction tests to skip.
           STELLA_TEST_REQUIRE_PACKAGED_XBERG: "1"
           STELLA_TEST_REQUIRE_SPA: "1"
+
+      - name: Upload system test diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: system-test-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: dist/logs/testbed/
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Prepare coverage report data
         run: |

--- a/deploy/helm/stella/Chart.yaml
+++ b/deploy/helm/stella/Chart.yaml
@@ -8,7 +8,7 @@ version: 0.1.5
 # against. It is NOT the default image tag: the chart defaults image.tag to
 # "latest" (see stella.image / values.yaml) so a fresh install tracks the newest
 # published release. Pin image.tag or image.digest for reproducible deploys.
-appVersion: "v0.68.0"
+appVersion: "v0.68.1"
 home: https://stella.cherryin.com
 sources:
   - https://github.com/CherryHQ/stella

--- a/mise.toml
+++ b/mise.toml
@@ -201,9 +201,12 @@ depends = ["pg:runtime:download"]
 run = "go test -race ./..."
 
 [tasks."test:coverage:race"]
-description = "Run tests with race detection and coverage report (CI)"
-depends = ["pg:runtime:download"]
-run = "go test -race -coverprofile=coverage.out ./..."
+description = "Run package race/coverage tests and the subprocess system suite (CI)"
+depends = ["pg:runtime:download", "build"]
+run = """
+go test -race -coverprofile=coverage.out ./...
+go test -tags system -count=1 -timeout 15m ./test/system/...
+"""
 
 [tasks."test:e2e"]
 description = "Run all Playwright end-to-end specs against a disposable testbed"

--- a/test/system/tool_smoke_test.go
+++ b/test/system/tool_smoke_test.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os/exec"
 	"slices"
 	"sort"
 	"strings"
@@ -138,9 +140,8 @@ func codeToolArguments(t *testing.T, source string) string {
 	return string(args)
 }
 
-// toolCanarySkillZIP returns a bash printf argument containing one complete ZIP
-// as hex escapes. printf is a bash builtin, so the real sandbox turn needs no
-// host-specific zip utility or language runtime to construct its input.
+// toolCanarySkillZIP uses POSIX printf %b octal escapes. The sandbox runs sh,
+// which may be dash on Linux and cannot decode bash-specific hex escapes.
 func toolCanarySkillZIP(t *testing.T) string {
 	t.Helper()
 	var archive bytes.Buffer
@@ -165,11 +166,45 @@ func toolCanarySkillZIP(t *testing.T) string {
 		t.Fatalf("close ZIP: %v", err)
 	}
 
-	escaped := make([]byte, 0, archive.Len()*4)
+	escaped := make([]byte, 0, archive.Len()*5)
 	for _, b := range archive.Bytes() {
-		escaped = fmt.Appendf(escaped, `\x%02x`, b)
+		escaped = fmt.Appendf(escaped, `\0%03o`, b)
 	}
 	return string(escaped)
+}
+
+func TestToolCanarySkillZIP(t *testing.T) {
+	for _, shell := range []string{"sh", "dash"} {
+		t.Run(shell, func(t *testing.T) {
+			path, err := exec.LookPath(shell)
+			if err != nil {
+				t.Skipf("%s is unavailable: %v", shell, err)
+			}
+			cmd := exec.CommandContext(t.Context(), path, "-c", `printf '%b' "$1"`, "printf", toolCanarySkillZIP(t))
+			data, err := cmd.Output()
+			if err != nil {
+				t.Fatal(err)
+			}
+			archive, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+			if err != nil {
+				t.Fatalf("%s printf produced an invalid ZIP: %v", shell, err)
+			}
+			asset, err := archive.Open("downloaded-package/assets/font.woff2")
+			if err != nil {
+				t.Fatal(err)
+			}
+			body, err := io.ReadAll(asset)
+			if closeErr := asset.Close(); closeErr != nil {
+				t.Fatal(closeErr)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(body, []byte{0x77, 0x4f, 0x46, 0x32, 0xff, 0x00}) {
+				t.Fatalf("%s printf corrupted the binary asset: %x", shell, body)
+			}
+		})
+	}
 }
 
 // childToolResult is one settled child invocation observed on the SSE stream.

--- a/web/content/docs/changelog.mdx
+++ b/web/content/docs/changelog.mdx
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.68.0] - 2026-09-05
+## [0.68.1] - 2026-09-05
+
+This is the first complete stable release of the 0.68 line. The v0.68.0 attempt stopped at the system-test gate after publishing only its sandbox image.
 
 ### ⚠️ Breaking Changes
 
@@ -25,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Bug Fixes
 
+- Generate the system canary ZIP with portable shell escapes, and run the subprocess system suite in the required PR Test check so Linux failures are caught before tagging. ([#1262](https://github.com/CherryHQ/stella/issues/1262))
 - Improve Feishu forwarded-message and media handling, add per-group controls and a joined-group picker, and make streaming cards preserve the latest update, split long Markdown safely, and show reasoning/tool progress. Use `/abort` to stop a turn; reply cards no longer have a Cancel button. ([#1254](https://github.com/CherryHQ/stella/pull/1254))
 - Carry forward the v0.67.0 fixes that prepare embedded runtimes for cross-platform GoReleaser and Docker builds. ([#1248](https://github.com/CherryHQ/stella/pull/1248), [#1249](https://github.com/CherryHQ/stella/pull/1249))
 
@@ -37,7 +40,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Require release notes, applicable metadata, and release-only fixes to be synced back to `main` before closing out a release. Restore the published 0.66.0, 0.66.1, and 0.67.0 records.
 
-**Full Changelog**: [v0.67.0...v0.68.0](https://github.com/CherryHQ/stella/compare/v0.67.0...v0.68.0)
+**Full Changelog**: [v0.67.0...v0.68.1](https://github.com/CherryHQ/stella/compare/v0.67.0...v0.68.1)
+
+## [0.68.0] - 2026-09-05
+
+Publication was incomplete: the tag and sandbox image were created, but the server binaries and main Docker image were not published because a test fixture failed under Linux sh. Use v0.68.1. ([#1261](https://github.com/CherryHQ/stella/pull/1261), [#1262](https://github.com/CherryHQ/stella/issues/1262))
 
 ## [0.67.0] - 2026-09-03
 

--- a/web/content/docs/changelog.zh.mdx
+++ b/web/content/docs/changelog.zh.mdx
@@ -11,7 +11,9 @@ icon: History
 
 ## [Unreleased]
 
-## [0.68.0] - 2026-09-05
+## [0.68.1] - 2026-09-05
+
+这是 0.68 系列首次完整的稳定发布。v0.68.0 在系统测试门禁失败，仅发布了 sandbox 镜像。
 
 ### ⚠️ Breaking Changes
 
@@ -25,6 +27,7 @@ icon: History
 
 ### 🐛 Bug Fixes
 
+- 使用可移植的 shell 转义生成系统 canary ZIP，并将真实进程系统测试接入 PR 必须通过的 Test 检查，在打 tag 前发现 Linux 失败。([#1262](https://github.com/CherryHQ/stella/issues/1262))
 - 改进飞书合并转发和媒体处理，新增按群配置及已加入群选择器；流式卡片保留最新更新、安全拆分长 Markdown，并展示推理和工具进度。回复卡片移除 Cancel 按钮，使用 `/abort` 停止当前轮次。([#1254](https://github.com/CherryHQ/stella/pull/1254))
 - 带回 v0.67.0 的构建修复，为跨平台 GoReleaser 和 Docker 构建准备嵌入运行时。([#1248](https://github.com/CherryHQ/stella/pull/1248), [#1249](https://github.com/CherryHQ/stella/pull/1249))
 
@@ -37,7 +40,11 @@ icon: History
 
 - 发布收尾前必须将发布说明、适用元数据及 release-only 修复同步回 `main`，并补齐已发布的 0.66.0、0.66.1、0.67.0 记录。
 
-**Full Changelog**: [v0.67.0...v0.68.0](https://github.com/CherryHQ/stella/compare/v0.67.0...v0.68.0)
+**Full Changelog**: [v0.67.0...v0.68.1](https://github.com/CherryHQ/stella/compare/v0.67.0...v0.68.1)
+
+## [0.68.0] - 2026-09-05
+
+此次发布未完成：tag 和 sandbox 镜像已创建，但测试夹具在 Linux sh 下失败，服务端二进制与主 Docker 镜像未发布。请使用 v0.68.1。([#1261](https://github.com/CherryHQ/stella/pull/1261), [#1262](https://github.com/CherryHQ/stella/issues/1262))
 
 ## [0.67.0] - 2026-09-03
 

--- a/web/content/docs/development/rules/release.md
+++ b/web/content/docs/development/rules/release.md
@@ -205,7 +205,7 @@ Apply to both changelog files:
 ## Validate and Test
 
 Run the full pre-cut gate — it executes, strictly in order, `format` → `build` →
-`test` → `test` → `release:check` → `release:snapshot`:
+`build:web` → `test` → `release:check` → `release:snapshot`:
 
 ```bash
 VERSION=X.Y.Z # or X.Y.Z-rc.N

--- a/web/content/docs/development/rules/release.zh.md
+++ b/web/content/docs/development/rules/release.zh.md
@@ -135,7 +135,7 @@ gh pr list --state merged --base "${RELEASE_BRANCH:-main}" --search "merged:>=$(
 
 ## 验证与测试
 
-运行完整发布前门禁。它严格按 `format` → `build` → `test` → `test` → `release:check` → `release:snapshot` 执行：
+运行完整发布前门禁。它严格按 `format` → `build` → `build:web` → `test` → `release:check` → `release:snapshot` 执行：
 
 ```bash
 VERSION=X.Y.Z # 或 X.Y.Z-rc.N
@@ -143,7 +143,7 @@ test "$(jq -r '.version' web/package.json)" = "$VERSION"
 mise run release:validate
 ```
 
-System Test 同时在本地门禁和 tag 触发的 validation job 中运行。发布 CI 固定使用支持的 Ubuntu runner，并在 snapshot build 清理 `dist/` 之前上传测试服务器日志。GoReleaser 与 Docker 发布 job 直接依赖 validation 结果，因此失败或不受支持的 System Test 无法发布部分工件。详见 `testing.zh.md`。
+本地门禁顺序执行，任一步失败都会停止后续工作。tag 工作流先验证发布来源，再并行运行质量检查与构建、Go/Web 测试、System Test 和 release snapshot；GoReleaser 与主 Docker 镜像发布必须等待四路全部通过。发布 CI 使用固定的 Ubuntu runner，System Test 在独立工作区中以 `if: always()` 上传测试日志。详见 `testing.zh.md`。
 
 ## Agent 性能门禁
 

--- a/web/content/docs/development/rules/testing.md
+++ b/web/content/docs/development/rules/testing.md
@@ -19,6 +19,12 @@ mise run eval:loop                        # Harbor behavior evaluation
 
 `mise run perf` runs both `test/e2e/perf/render.spec.ts` and `load.spec.ts`, with the testbed's embedded fake model. `mise run testbed:start` and `mise run testbed:stop` remain available for manual API and browser exploration. `test:web`, coverage, race, and `eval:*` tasks remain specialized commands rather than additional functional test layers.
 
+The required PR Test check runs `mise run test:coverage:race`: it builds the
+server, runs package tests with race detection and coverage, then runs the
+subprocess system suite without race instrumentation. Frontend tests run in a
+separate step. System logs are uploaded even on failure, so Linux process
+regressions are checked before tagging rather than first discovered by release CI.
+
 ## Where to write tests
 
 Every behavior has three possible homes:

--- a/web/content/docs/development/rules/testing.zh.md
+++ b/web/content/docs/development/rules/testing.zh.md
@@ -19,6 +19,10 @@ mise run eval:loop                        # Harbor 行为评估
 
 `mise run perf` 一次运行 `test/e2e/perf/render.spec.ts` 和 `load.spec.ts`，使用 testbed 内嵌的假模型。`mise run testbed:start` 和 `mise run testbed:stop` 保留给手工 API/浏览器探索。`test:web`、coverage、race 和 `eval:*` 是专门命令，不是额外的功能测试层。
 
+PR 必须通过的 Test 检查运行 `mise run test:coverage:race`：先构建服务端，运行
+带 race 检测和覆盖率的包测试，再运行不带 race 的真实进程系统测试。前端测试
+单独执行。系统日志在失败时也会上传，Linux 进程回归必须在打 tag 前接受检查。
+
 ## 写在哪
 
 每个行为有三个可能落点：

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.68.0",
+  "version": "0.68.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What

Prepare v0.68.1 stable, fix the managed-Skill ZIP fixture for sh/dash, and require subprocess system tests in PR CI before tagging.

## Why

The v0.68.0 Release workflow failed in both system-test lanes because the sandbox executes sh on Linux, where dash does not decode the previous bash-specific `\xNN` escapes. The resulting file was not a ZIP. macOS validation passed because its shell accepts those escapes.

## How

- Replace hexadecimal escapes with `\0NNN` octal escapes, retaining the complete binary ZIP fixture and production Skill ingestion journey.
- Add a regression test that executes sh and available dash, opens the resulting ZIP, and compares the embedded binary asset byte-for-byte.
- Extend the existing `test:coverage:race` task with the server build prerequisite and the non-race system suite; upload system diagnostics even on failure. Update bilingual testing documentation and correct the release gate sequence and Chinese CI description.
- Set Web and Helm app versions to v0.68.1. Retain chart version 0.1.5 because the chart itself did not change.
- Mark v0.68.0 as an incomplete publication in both changelogs, retain all feature notes under v0.68.1, and preserve the published v0.67.0-and-earlier history.
- Keep the v0.68.0 tag and sandbox image unchanged. No production behavior changes and no test is skipped to bypass the release failure.
- v0.68.1 is published at `a5424ced07c063fc40ba55fa4a3085ee3c6e12f8`; all Release and sandbox jobs succeeded. Sync-back #1264 is merged into main at `0dd22fdab8712128437bd07681d99de1b32b3f15`; its file tree is identical to v0.68.1.

## Test

- Before the fix, `mise exec -- go test -tags system ./test/system -run '^TestToolCanarySkillZIP$' -count=1` failed under dash with `zip: not a valid zip file`.
- After the fix, the same sh/dash regression passed.
- `mise exec -- go test -tags system ./test/system -run '^TestSystem$/(startup_and_auth|tool_smoke_canary)$' -count=1 -timeout 5m` passed, exercising the real-process SSE/Skill package path. The authentication journey is a prerequisite for this suite.
- `mise run format && mise run build && mise run test` passed for the fixture fix, including 344 Web tests and the complete system suite (94.936s).
- Final `mise run release:validate` for v0.68.1 passed: format, build, Go tests, 344 Web tests, system tests (94.243s), GoReleaser checks, four-platform archives and Linux packages, and host archive verification.
- Hosted Format, Windows compile-only, and Test passed. The Test job includes package race/coverage and the Linux subprocess system suite: https://github.com/CherryHQ/stella/actions/runs/33939869844 . Local race tests were not duplicated; CI owns that lane.
- No new Terminal-Bench run or agent-performance claim. This patch changes release bookkeeping and deterministic test/CI behavior; feature-level limitations remain recorded in #1261.

## Refs

Release: https://github.com/CherryHQ/stella/releases/tag/v0.68.1
Publication: https://github.com/CherryHQ/stella/actions/runs/33940344208
Sync-back: #1264

Refs #1262. Close the implementation issue after the release-branch merge and Linux system checks pass; publication and sync-back remain tracked by the version milestone.

Preparation: #1261
Failed release run: https://github.com/CherryHQ/stella/actions/runs/33938226261

## Checklist

- [x] The PR references #1262 for the portability failure and missing pre-tag system gate.
- [x] Added and demonstrated a failing-then-passing shell regression test, plus the real-process canary.
- [x] English and Chinese changelogs and testing documentation are updated.
- [x] I ran `mise run format && mise run build && mise run test`.
- [x] Agent eval is not applicable to test fixture encoding; no production tool, prompt, or runner behavior changes.
- [x] Binary ZIP contents are verified byte-for-byte by the regression, and Skill ingestion is exercised by the canary.
- [x] The failed release result is retained in #1261; no earlier evaluation is erased or relabeled.
