### PR TITLE
⚡ ci: reduce PR and release pipeline duplication

### DIFF
--- a/.github/actions/toolchain-caches/action.yml
+++ b/.github/actions/toolchain-caches/action.yml
@@ -5,17 +5,15 @@ description: >-
   recompiles the whole Go module, re-downloads 576 npm packages, re-fetches
   dprint's WASM plugins, and re-downloads the PostgreSQL runtime.
 
-  Only the Go *build* cache is scoped per job. Everything else is byte-identical
-  across jobs, and the repository shares a 10 GB cache budget that these entries
-  can exhaust on their own — a duplicate copy is not free, it evicts something
-  another job needed.
+  Go objects are shared by compilation mode, not workflow name. Long-lived
+  branches refresh them after successful checks; PRs only restore them.
+  Download caches remain keyed by their immutable dependency inputs.
 
 inputs:
   scope:
     description: >-
-      Namespace for the Go build cache only. Jobs whose compiled objects differ
-      need different scopes: race-instrumented objects are a separate build
-      graph, so sharing a key would make those jobs evict each other every run.
+      Go compilation mode: plain, race, or windows. Cross builds restore plain
+      host objects and keep target objects local instead of caching every tag.
     required: true
   go:
     description: Cache GOCACHE and GOMODCACHE.
@@ -30,6 +28,14 @@ inputs:
     required: false
     default: "false"
 
+outputs:
+  go-build-path:
+    value: ${{ steps.go-paths.outputs.build }}
+    description: Go build cache directory for the successful branch writer.
+  go-build-key:
+    value: ${{ steps.go-build.outputs.cache-primary-key }}
+    description: Immutable key for this commit and compilation mode.
+
 runs:
   using: composite
   steps:
@@ -42,6 +48,7 @@ runs:
       run: |
         echo "build=$(mise exec -- go env GOCACHE)" >> "$GITHUB_OUTPUT"
         echo "mod=$(mise exec -- go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+        echo "version=$(mise exec -- go env GOVERSION)" >> "$GITHUB_OUTPUT"
 
     # Downloaded module source, identical for every job on a given go.sum.
     # Unscoped on purpose: this is the larger half of a Go cache, and scoping it
@@ -55,18 +62,19 @@ runs:
         restore-keys: |
           gomod-${{ runner.os }}-
 
-    # Compiled objects, which genuinely differ per job. restore-keys fall back
-    # progressively because this cache is content-addressed: a partial hit after
-    # a go.sum change still carries most of the saving.
-    - name: Cache Go build cache
+    # A new commit can add compiled objects even when dependencies are unchanged.
+    # Readers fall back to the newest compatible successful branch snapshot.
+    - name: Restore Go build cache
       if: inputs.go == 'true'
-      uses: actions/cache@v6
+      id: go-build
+      uses: actions/cache/restore@v6
       with:
         path: ${{ steps.go-paths.outputs.build }}
-        key: gobuild-${{ inputs.scope }}-${{ runner.os }}-${{ hashFiles('mise.toml') }}-${{ hashFiles('go.sum') }}
+        key: gobuild-v2-${{ inputs.scope }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-paths.outputs.version }}-${{ hashFiles('go.sum') }}-${{ github.sha }}
         restore-keys: |
-          gobuild-${{ inputs.scope }}-${{ runner.os }}-${{ hashFiles('mise.toml') }}-
-          gobuild-${{ inputs.scope }}-${{ runner.os }}-
+          gobuild-v2-${{ inputs.scope }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-paths.outputs.version }}-${{ hashFiles('go.sum') }}-
+          gobuild-v2-${{ inputs.scope }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.go-paths.outputs.version }}-
+          gobuild-${{ inputs.scope == 'plain' && 'format' || inputs.scope }}-${{ runner.os }}-
 
     # Both pnpm store locations are listed because the path depends on the pnpm
     # version vp delegates to. A path that does not exist is skipped, so a wrong

--- a/.github/scripts/copy-image-tags.sh
+++ b/.github/scripts/copy-image-tags.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Cross-registry blob transfer happens once. Remaining aliases use the manifest
+# already in the destination repository, avoiding another remote copy per tag.
+if [ "$#" -lt 3 ]; then
+  echo "usage: $0 SOURCE DESTINATION_REPOSITORY TAG [TAG...]" >&2
+  exit 1
+fi
+source_image=$1
+destination=$2
+shift 2
+first_tag=$1
+shift
+docker buildx imagetools create -t "$destination:$first_tag" "$source_image"
+if [ "$#" -gt 0 ]; then
+  aliases=()
+  for tag in "$@"; do aliases+=("-t" "$destination:$tag"); done
+  docker buildx imagetools create "${aliases[@]}" "$destination:$first_tag"
+fi

--- a/.github/scripts/copy-image-tags_test.sh
+++ b/.github/scripts/copy-image-tags_test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+script="$(cd "$(dirname "$0")" && pwd)/copy-image-tags.sh"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+cat > "$tmp/docker" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CALLS"
+if [ "${FAIL_COPY:-0}" = 1 ]; then exit 42; fi
+MOCK
+chmod +x "$tmp/docker"
+export PATH="$tmp:$PATH" CALLS="$tmp/calls"
+
+bash "$script" source.example/stella@sha256:abc mirror.example/stella v1.2.3 latest sha-abc
+cat > "$tmp/expected" <<'EXPECTED'
+buildx imagetools create -t mirror.example/stella:v1.2.3 source.example/stella@sha256:abc
+buildx imagetools create -t mirror.example/stella:latest -t mirror.example/stella:sha-abc mirror.example/stella:v1.2.3
+EXPECTED
+diff -u "$tmp/expected" "$CALLS"
+
+: > "$CALLS"
+if FAIL_COPY=1 bash "$script" source.example/stella@sha256:abc mirror.example/stella v1.2.3 latest; then
+  echo 'copy failure was ignored' >&2; exit 1
+fi
+test "$(wc -l < "$CALLS" | tr -d ' ')" = 1
+: > "$CALLS"
+bash "$script" source.example/stella@sha256:abc mirror.example/stella v1.2.3-rc.1
+test "$(wc -l < "$CALLS" | tr -d ' ')" = 1
+if bash "$script" source.example/stella mirror.example/stella; then
+  echo 'missing tags were accepted' >&2; exit 1
+fi
+echo 'Image promotion: one remote copy, local aliases, and failure propagation passed'

--- a/.github/scripts/verify-ci-policy_test.sh
+++ b/.github/scripts/verify-ci-policy_test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+# Exercise the actual required-check command for all GitHub job outcomes. A
+# skipped/cancelled prerequisite must never turn the aggregate green.
+pr=.github/workflows/lint-and-test.yml
+release=.github/workflows/release.yml
+sandbox=.github/workflows/sandbox-docker.yml
+test "$(yq '.jobs.test.if' "$pr")" = 'always()'
+test "$(yq '.jobs.test.needs | sort | join(",")' "$pr")" = 'packages,system'
+join_command=$(yq '.jobs.test.steps[0].run' "$pr")
+for packages in success failure cancelled skipped; do
+  for system in success failure cancelled skipped; do
+    if PACKAGE_RESULT=$packages SYSTEM_RESULT=$system bash -c "$join_command"; then
+      test "$packages/$system" = success/success
+    else
+      test "$packages/$system" != success/success
+    fi
+  done
+done
+
+# All validation and image candidates must succeed before GoReleaser can publish.
+test "$(yq '.jobs.goreleaser.needs | sort | join(",")' "$release")" = 'docker,quality,sandbox,system,tests'
+test "$(yq '.jobs.merge.needs | sort | join(",")' "$release")" = 'docker,goreleaser,sandbox'
+test "$(yq '.jobs.source.steps[] | select(.name == "Verify tag identity and release branch") | .if' "$release")" = "github.event_name == 'push'"
+test "$(yq '.on.push | keys | join(",")' "$release")" = tags
+test "$(yq '.jobs.goreleaser.steps[] | select(.name == "Run GoReleaser") | .if' "$release")" = "github.event_name == 'push'"
+test "$(yq '.jobs.merge.if' "$release")" = "github.event_name == 'push'"
+test "$(yq '.on.push.tags' "$sandbox")" = null
+test "$(yq '.jobs.sandbox.with.candidate' "$release")" = true
+
+# Read-only rehearsals must not push candidate images, even on workflow_dispatch.
+push_condition="\${{ github.event_name == 'push' }}"
+test "$(yq '.jobs.docker.steps[] | select(.id == "build") | .with.push' "$release")" = "$push_condition"
+test "$(yq '.jobs.build.steps[] | select(.id == "build") | .with.push' "$sandbox")" = "$push_condition"
+
+echo 'CI policy: aggregate outcomes and release publication gates passed'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,16 @@
 name: Build and Push Docker Image
 
 on:
-  pull_request:
+  push:
     branches: [main]
+  pull_request:
+    branches: [main, "release/v*"]
+  merge_group:
+    types: [checks_requested]
+
+concurrency:
+  group: docker-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -26,27 +34,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Setup mise
-        uses: jdx/mise-action@v4
-        with:
-          experimental: true
-          install: true
-          cache: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Restore toolchain caches
-        uses: ./.github/actions/toolchain-caches
-        with:
-          scope: docker
-
-      - name: Generate code
-        run: mise run generate
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Log into GitHub Container Registry
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -66,19 +58,16 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-          # This workflow only triggers on pull_request, so the old
-          # `event_name != 'pull_request'` guard on cache-to meant the layer
-          # cache was never written — and the registry tag it read from is not
-          # the one release.yml writes (`buildcache-<suffix>`), so cache-from
-          # missed every time too. The GitHub Actions cache needs no registry
-          # push, which is what makes it usable on a pull_request run.
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          # main warms the registry cache for both PRs and release amd64 builds.
+          cache-from: |
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-amd64
+            type=gha,scope=stella-amd64
+          cache-to: ${{ github.event_name == 'push' && format('type=registry,ref={0}/{1}:buildcache-amd64,mode=max', env.REGISTRY, env.IMAGE_NAME) || 'type=gha,scope=stella-amd64,mode=max' }}
           build-args: |
             VERSION=${{ github.sha }}
           secrets: |

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -36,21 +36,25 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore toolchain caches
+        id: caches
         uses: ./.github/actions/toolchain-caches
         with:
-          scope: format
+          scope: plain
 
       - name: Generate code and check drift
         run: mise run generate:check
 
       - name: Test release source policy
-        run: bash .github/scripts/verify-release-source_test.sh
+        run: |
+          bash .github/scripts/verify-release-source_test.sh
+          bash .github/scripts/verify-ci-policy_test.sh
+          bash .github/scripts/copy-image-tags_test.sh
 
       - name: Run pre-commit hooks
         run: prek run --all-files
 
-  test:
-    name: Test
+  packages:
+    name: Package race and Web tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -64,9 +68,8 @@ jobs:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Scoped "race": these objects are built with -race and must not share a
-      # build cache key with the Format job's plain ones.
       - name: Restore toolchain caches
+        id: caches
         uses: ./.github/actions/toolchain-caches
         with:
           scope: race
@@ -84,38 +87,12 @@ jobs:
           # Fail here, with the reason visible, rather than inside a test run.
           bwrap --unshare-pid --unshare-ipc --unshare-uts --dev-bind / / -- true
 
-      - name: Generate code and check drift
-        run: mise run generate:check
-
-      # go:embed snapshots web/static/dist at compile time, so this has to run
-      # before the test binaries are built. Without it the PWA build contract
-      # only gets checked at tag time, and a commit that breaks the Web UI's
-      # installability merges green.
-      - name: Build web assets
-        run: mise run build:web
-
-      # The race/coverage task covers Go and process tests; run frontend tests
-      # separately so a PR cannot merge with failing Web guards.
-      - name: Run frontend tests
-        run: mise run test:web
-
-      - name: Run package race/coverage and subprocess system tests
+      - name: Run package race/coverage and frontend tests
         run: mise run test:coverage:race
         env:
           STELLA_TEST_REQUIRE_BWRAP: "1"
-          # Keep the public Library allowlist tied to the exact Xberg bundle
-          # generated above instead of allowing real extraction tests to skip.
           STELLA_TEST_REQUIRE_PACKAGED_XBERG: "1"
           STELLA_TEST_REQUIRE_SPA: "1"
-
-      - name: Upload system test diagnostics
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: system-test-logs-${{ github.run_id }}-${{ github.run_attempt }}
-          path: dist/logs/testbed/
-          if-no-files-found: ignore
-          retention-days: 7
 
       - name: Prepare coverage report data
         run: |
@@ -158,6 +135,68 @@ jobs:
           path: coverage.out
           retention-days: 7
 
+      - name: Save successful branch Go cache
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ steps.caches.outputs.go-build-path }}
+          key: ${{ steps.caches.outputs.go-build-key }}
+
+  system:
+    name: Linux subprocess system tests
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - uses: jdx/mise-action@v4
+        with:
+          experimental: true
+          install: true
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Restore toolchain caches
+        id: caches
+        uses: ./.github/actions/toolchain-caches
+        with:
+          scope: plain
+          pg: "true"
+      - name: Enable sandbox namespaces
+        run: |
+          sudo apt-get install -y bubblewrap
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          bwrap --unshare-pid --unshare-ipc --unshare-uts --dev-bind / / -- true
+      - name: Run subprocess journeys
+        run: mise run test:system
+        env:
+          STELLA_TEST_REQUIRE_BWRAP: "1"
+          STELLA_TEST_REQUIRE_PACKAGED_XBERG: "1"
+          STELLA_TEST_REQUIRE_SPA: "1"
+      - name: Upload system diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: system-test-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: dist/logs/testbed/
+          if-no-files-found: ignore
+          retention-days: 7
+      - name: Save successful branch Go cache
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ steps.caches.outputs.go-build-path }}
+          key: ${{ steps.caches.outputs.go-build-key }}
+
+  test:
+    name: Test
+    if: always()
+    needs: [packages, system]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Require every test lane
+        env:
+          PACKAGE_RESULT: ${{ needs.packages.result }}
+          SYSTEM_RESULT: ${{ needs.system.result }}
+        run: test "$PACKAGE_RESULT" = success && test "$SYSTEM_RESULT" = success
+
   windows-bundle:
     name: Windows compile-only portability
     runs-on: windows-latest
@@ -176,6 +215,7 @@ jobs:
 
       # No Node or lint work here: this job only compiles Go.
       - name: Restore toolchain caches
+        id: caches
         uses: ./.github/actions/toolchain-caches
         with:
           scope: windows
@@ -193,3 +233,10 @@ jobs:
 
       - name: Compile portable Home and Skill packages without running tests
         run: mise exec -- go test ./internal/platform/home/... ./internal/skill/... ./internal/reflect/... -run '^$'
+
+      - name: Save successful branch Go cache
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ steps.caches.outputs.go-build-path }}
+          key: ${{ steps.caches.outputs.go-build-key }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,24 @@ name: Release
 on:
   push:
     tags: ["v*.*.*"]
+  # Changes to publication mechanics get a full, non-publishing rehearsal.
+  pull_request:
+    paths:
+      - ".github/workflows/release.yml"
+      - ".github/workflows/sandbox-docker.yml"
+      - ".github/actions/toolchain-caches/**"
+      - ".github/scripts/*image*"
+      - ".github/scripts/*release*"
+      - ".goreleaser.yaml"
+      - "Dockerfile"
+      - "plugins/sandbox/docker/Dockerfile"
+      - ".mise/tasks/release/**"
+      - "mise.toml"
+  workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -30,6 +48,7 @@ jobs:
           fetch-depth: 0
 
       - name: Verify tag identity and release branch
+        if: github.event_name == 'push'
         env:
           EVENT_REF: ${{ github.ref }}
           EVENT_SHA: ${{ github.sha }}
@@ -72,13 +91,16 @@ jobs:
       - name: Restore toolchain caches
         uses: ./.github/actions/toolchain-caches
         with:
-          scope: release-verify
+          scope: plain
 
       - name: Generate code and check drift
         run: mise run generate:check
 
       - name: Test release source policy
-        run: bash .github/scripts/verify-release-source_test.sh
+        run: |
+          bash .github/scripts/verify-release-source_test.sh
+          bash .github/scripts/verify-ci-policy_test.sh
+          bash .github/scripts/copy-image-tags_test.sh
 
       - name: Check formatting and lint
         run: |
@@ -112,7 +134,7 @@ jobs:
       - name: Restore toolchain caches
         uses: ./.github/actions/toolchain-caches
         with:
-          scope: release-tests
+          scope: plain
           pg: "true"
 
       - name: Install bubblewrap
@@ -122,18 +144,11 @@ jobs:
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
           bwrap --unshare-pid --unshare-ipc --unshare-uts --dev-bind / / -- true
 
-      - name: Generate code and check drift
-        run: mise run generate:check
-
-      # go:embed snapshots web/static/dist at compile time. Build the SPA before
-      # test binaries so the PWA contract cannot silently skip.
-      - name: Build web assets
-        run: mise run build:web
-
-      - name: Run Go and Web tests
-        run: mise run test
+      - name: Run package Go and Web tests
+        run: mise run test:packages
         env:
           STELLA_TEST_REQUIRE_BWRAP: "1"
+          STELLA_TEST_REQUIRE_PACKAGED_XBERG: "1"
           STELLA_TEST_REQUIRE_SPA: "1"
 
   system:
@@ -159,7 +174,7 @@ jobs:
       - name: Restore toolchain caches
         uses: ./.github/actions/toolchain-caches
         with:
-          scope: release-system
+          scope: plain
           pg: "true"
 
       - name: Install bubblewrap
@@ -169,8 +184,12 @@ jobs:
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
           bwrap --unshare-pid --unshare-ipc --unshare-uts --dev-bind / / -- true
 
-      - name: Run tests (Go, web, system suite)
-        run: mise run test
+      - name: Run subprocess system journeys
+        run: mise run test:system
+        env:
+          STELLA_TEST_REQUIRE_BWRAP: "1"
+          STELLA_TEST_REQUIRE_PACKAGED_XBERG: "1"
+          STELLA_TEST_REQUIRE_SPA: "1"
 
       - name: Upload testbed diagnostics
         if: always()
@@ -181,41 +200,21 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  snapshot:
-    name: Release Snapshot
+  sandbox:
+    name: Sandbox candidate
     needs: source
-    runs-on: ubuntu-24.04
     permissions:
       contents: read
-    steps:
-      - name: Checkout tagged commit
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.sha }}
-          fetch-depth: 0
-
-      - name: Setup mise
-        uses: jdx/mise-action@v4
-        with:
-          experimental: true
-          install: true
-          cache: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Restore toolchain caches
-        uses: ./.github/actions/toolchain-caches
-        with:
-          scope: release-snapshot
-
-      - name: Check GoReleaser configuration
-        run: mise run release:check
-
-      - name: Build release snapshot
-        run: mise run release:snapshot
+      packages: write
+      id-token: write
+    uses: ./.github/workflows/sandbox-docker.yml
+    with:
+      candidate: true
+    secrets: inherit
 
   goreleaser:
     name: GoReleaser
-    needs: [quality, tests, system, snapshot]
+    needs: [quality, tests, system, docker, sandbox]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -239,21 +238,27 @@ jobs:
       - name: Restore toolchain caches
         uses: ./.github/actions/toolchain-caches
         with:
-          scope: release-goreleaser
+          scope: plain
 
+      - name: Check release configuration
+        run: mise run release:check
+
+      # Formal releases build all four targets once, after every validation and
+      # image build succeeded. PRs exercise the same configuration without writes.
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
-        with:
-          distribution: goreleaser
-          version: "~> v2"
-          args: release --clean
+        if: github.event_name == 'push'
+        run: mise exec -- goreleaser release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
+      - name: Rehearse four-platform release without publishing
+        if: github.event_name != 'push'
+        run: mise run release:snapshot
+
   docker:
     name: Docker Release
-    needs: [quality, tests, system, snapshot]
+    needs: source
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -284,6 +289,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log into GitHub Container Registry
+        if: github.event_name == 'push'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -295,27 +301,29 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          push: true
+          push: ${{ github.event_name == 'push' }}
           platforms: ${{ matrix.platform }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ github.ref_name }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ matrix.suffix }}
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ matrix.suffix }},mode=max
+          cache-to: ${{ github.event_name == 'push' && format('type=registry,ref={0}/{1}:buildcache-{2},mode=max', env.REGISTRY, env.IMAGE_NAME, matrix.suffix) || format('type=gha,scope=release-{0},mode=max', matrix.suffix) }}
           build-args: |
             VERSION=${{ github.ref_name }}
           secrets: |
             github_token=${{ secrets.GITHUB_TOKEN }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          outputs: ${{ github.event_name == 'push' && format('type=image,name={0}/{1},push-by-digest=true,name-canonical=true,push=true', env.REGISTRY, env.IMAGE_NAME) || '' }}
 
       - name: Export digest
+        if: github.event_name == 'push'
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v7
         with:
           name: digests-${{ matrix.suffix }}
@@ -326,13 +334,19 @@ jobs:
   merge:
     name: Merge Docker Manifests
     runs-on: ubuntu-latest
-    needs: [goreleaser, docker]
+    needs: [goreleaser, docker, sandbox]
+    if: github.event_name == 'push'
 
     permissions:
       contents: read
       packages: write
 
     steps:
+      - name: Checkout publishing scripts
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+
       - name: Download digests
         uses: actions/download-artifact@v8
         with:
@@ -361,10 +375,33 @@ jobs:
             type=semver,pattern={{raw}}
 
       - name: Create manifest list and push
+        env:
+          IMAGE_METADATA: ${{ steps.meta.outputs.json }}
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$IMAGE_METADATA") \
             $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Extract sandbox tags
+        id: sandbox-meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/cherryhq/stella-sandbox
+          tags: |
+            type=sha,format=long
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref_name, '-') }}
+            type=semver,pattern={{major}},enable=${{ !contains(github.ref_name, '-') }}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+
+      - name: Publish validated sandbox aliases
+        env:
+          SANDBOX_DIGEST: ${{ needs.sandbox.outputs.digest }}
+          SANDBOX_METADATA: ${{ steps.sandbox-meta.outputs.json }}
+        run: |
+          tags=()
+          while IFS= read -r tag; do tags+=("-t" "$tag"); done < <(jq -r '.tags[]' <<< "$SANDBOX_METADATA")
+          docker buildx imagetools create "${tags[@]}" "ghcr.io/cherryhq/stella-sandbox@$SANDBOX_DIGEST"
 
       - name: Inspect stable image
         if: ${{ !contains(github.ref_name, '-') }}
@@ -381,8 +418,9 @@ jobs:
 
       - name: Copy manifest list to mirror registry
         if: env.ACR_REGISTRY != ''
+        env:
+          IMAGE_METADATA: ${{ steps.meta.outputs.json }}
         run: |
-          for source in $(jq -cr '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON"); do
-            target="${ACR_REGISTRY}/${ACR_IMAGE_NAME}:${source##*:}"
-            docker buildx imagetools create -t "$target" "$source"
-          done
+          tags=()
+          while IFS= read -r tag; do tags+=("${tag##*:}"); done < <(jq -r '.tags[]' <<< "$IMAGE_METADATA")
+          bash .github/scripts/copy-image-tags.sh "${REGISTRY}/${IMAGE_NAME}:${GITHUB_REF_NAME}" "${ACR_REGISTRY}/${ACR_IMAGE_NAME}" "${tags[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,7 +308,9 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ github.ref_name }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ matrix.suffix }}
-          cache-to: ${{ github.event_name == 'push' && format('type=registry,ref={0}/{1}:buildcache-{2},mode=max', env.REGISTRY, env.IMAGE_NAME, matrix.suffix) || format('type=gha,scope=release-{0},mode=max', matrix.suffix) }}
+          # Rehearsals only read the published builder cache. Exporting all
+          # intermediate layers to a PR-only cache cost 4m29s on arm64.
+          cache-to: ${{ github.event_name == 'push' && format('type=registry,ref={0}/{1}:buildcache-{2},mode=max', env.REGISTRY, env.IMAGE_NAME, matrix.suffix) || '' }}
           build-args: |
             VERSION=${{ github.ref_name }}
           secrets: |

--- a/.github/workflows/sandbox-docker.yml
+++ b/.github/workflows/sandbox-docker.yml
@@ -1,9 +1,18 @@
 name: Build and Push Sandbox Docker Image
 
 on:
+  workflow_call:
+    inputs:
+      candidate:
+        description: Build a digest-only release candidate; the caller owns aliases.
+        type: boolean
+        default: false
+    outputs:
+      digest:
+        description: Multi-platform sandbox image digest.
+        value: ${{ jobs.build.outputs.digest }}
   push:
     branches: [main]
-    tags: ["v*.*.*"]
     paths:
       - "plugins/sandbox/docker/**"
       - "resources/**"
@@ -14,6 +23,10 @@ on:
       - "plugins/sandbox/docker/**"
       - "resources/**"
       - ".github/workflows/sandbox-docker.yml"
+
+concurrency:
+  group: sandbox-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -27,6 +40,8 @@ jobs:
   build:
     name: Build Sandbox Docker Image
     runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
 
     permissions:
       contents: read
@@ -45,6 +60,11 @@ jobs:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Restore toolchain caches
+        uses: ./.github/actions/toolchain-caches
+        with:
+          scope: plain
+
       - name: Generate code
         run: mise run generate
 
@@ -59,7 +79,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log into GitHub Container Registry
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -82,13 +102,15 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
           file: plugins/sandbox/docker/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ !inputs.candidate && steps.meta.outputs.tags || '' }}
+          outputs: ${{ inputs.candidate && github.event_name == 'push' && format('type=image,name={0}/{1},push-by-digest=true,name-canonical=true,push=true', env.REGISTRY, env.IMAGE_NAME) || '' }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -96,6 +118,6 @@ jobs:
             VERSION=${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha }}
             BUILTIN_BUNDLE_REVISION=${{ steps.builtin-bundle.outputs.revision }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}:buildcache,mode=max', env.REGISTRY, env.IMAGE_NAME) || '' }}
+          cache-to: ${{ github.event_name == 'push' && format('type=registry,ref={0}/{1}:buildcache,mode=max', env.REGISTRY, env.IMAGE_NAME) || '' }}
           secrets: |
             github_token=${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -90,4 +90,4 @@ release:
   prerelease: auto
   footer: |
     ---
-    **Full Changelog**: See [Changelog](https://github.com/CherryHQ/stella/blob/main/docs/content/docs/changelog.mdx) for categorized details.
+    **Full Changelog**: See [Changelog](https://github.com/CherryHQ/stella/blob/main/web/content/docs/changelog.mdx) for categorized details.

--- a/.mise/tasks/test/system
+++ b/.mise/tasks/test/system
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#MISE description="Run subprocess system journeys with freshly built embedded assets (CI)"
+#MISE depends=["generate:check", "build:embedded"]
+set -euo pipefail
+
+mise run build
+# Use the binary just built instead of compiling another server through go run.
+./dist/bin/stellad postgres download
+go test -tags system -count=1 -timeout 15m ./test/system/...

--- a/mise.toml
+++ b/mise.toml
@@ -201,11 +201,22 @@ depends = ["pg:runtime:download"]
 run = "go test -race ./..."
 
 [tasks."test:coverage:race"]
-description = "Run package race/coverage tests and the subprocess system suite (CI)"
-depends = ["pg:runtime:download", "build"]
+description = "Run package race/coverage and frontend tests (CI)"
+depends = ["generate:check", "build:embedded"]
 run = """
+# go:embed must not race a still-running SPA build.
+go run ./cmd/stellad postgres download
 go test -race -coverprofile=coverage.out ./...
-go test -tags system -count=1 -timeout 15m ./test/system/...
+mise run test:web
+"""
+
+[tasks."test:packages"]
+description = "Run package Go and frontend tests without repeating system journeys (CI)"
+depends = ["generate:check", "build:embedded"]
+run = """
+go run ./cmd/stellad postgres download
+go test ./...
+mise run test:web
 """
 
 [tasks."test:e2e"]

--- a/web/content/docs/development/rules/release.md
+++ b/web/content/docs/development/rules/release.md
@@ -213,15 +213,31 @@ test "$(jq -r '.version' web/package.json)" = "$VERSION"
 mise run release:validate
 ```
 
-The local gate remains sequential so the first failure stops later work. The
-tag workflow verifies the release source once, then runs quality/build, Go and
-Web tests, the System Test, and the release snapshot in parallel. GoReleaser and
-Docker publication depend on all four jobs. A failure in any lane blocks every
-publication job.
+The local gate remains sequential. The tag workflow verifies the exact source,
+then runs quality/build, package Go/Web tests, subprocess system tests, and main
+and sandbox image builds in parallel. Each test suite runs once. Images are
+uploaded by digest only; no version, latest, or sandbox compatibility alias moves
+at this stage. Failed runs may leave untagged candidate images and build caches.
 
-Release CI pins supported Ubuntu runners. The System Test lane uploads its server
-logs with `if: always()` before any other job can affect its isolated workspace,
-so failed subprocess journeys remain diagnosable. See `testing.md`.
+After every validation and image build succeeds, the pinned GoReleaser builds and
+publishes all four platforms once. Tag CI no longer builds a duplicate snapshot
+first; the local pre-cut snapshot remains required. Main and sandbox aliases are
+published only after GoReleaser succeeds. Mirror transfer copies the manifest to
+the destination once, then creates its other aliases from that destination.
+
+Publishing across GitHub, Homebrew, GHCR, and the mirror is not transactional.
+If a publication step fails, retain the tag, inspect which artifacts already
+exist, and rerun only the failed jobs for that same run. A failed validation never
+permits publishing aliases; a failed mirror copy does not make the release
+complete. Do not retag to repair publication. Finish verification and sync-back
+before closing the milestone.
+
+Changes to release mechanics trigger a PR rehearsal, and `workflow_dispatch`
+can rehearse a selected branch. Both modes build images without pushing and run
+the four-platform snapshot instead of publishing binaries or Homebrew. Only a
+tag-push event can publish. Hosted system logs are uploaded with `if: always()`;
+see `testing.md`. Rehearsal timing does not measure registry uploads or mirror
+transfer, and warm-cache timing requires a successful branch cache writer first.
 
 ## Agent Performance Gate
 

--- a/web/content/docs/development/rules/release.zh.md
+++ b/web/content/docs/development/rules/release.zh.md
@@ -143,7 +143,25 @@ test "$(jq -r '.version' web/package.json)" = "$VERSION"
 mise run release:validate
 ```
 
-本地门禁顺序执行，任一步失败都会停止后续工作。tag 工作流先验证发布来源，再并行运行质量检查与构建、Go/Web 测试、System Test 和 release snapshot；GoReleaser 与主 Docker 镜像发布必须等待四路全部通过。发布 CI 使用固定的 Ubuntu runner，System Test 在独立工作区中以 `if: always()` 上传测试日志。详见 `testing.zh.md`。
+本地门禁仍顺序执行。tag 工作流验证确切来源后，并行运行质量检查与构建、
+Go/Web 包测试、子进程系统测试、主镜像和 sandbox 镜像构建。每套测试只跑一次。
+镜像此时只按 digest 上传，不移动版本、latest 或 sandbox 兼容性别名。失败运行
+可能留下未打 tag 的候选镜像和构建缓存。
+
+所有验证和镜像构建成功后，固定版本的 GoReleaser 构建并发布四个平台一次。
+tag CI 不再先重复构建 snapshot，本地发布前 snapshot 仍是必需门禁。
+GoReleaser 成功后才发布主镜像与 sandbox 别名。镜像仓库复制先完成一次跨仓库
+传输，再从目标仓库中的 manifest 建立其他别名。
+
+GitHub、Homebrew、GHCR 和镜像仓库之间没有事务。发布步骤失败时保留 tag，
+检查已有产物，并重跑同一次运行的失败任务。验证失败不能放行镜像别名；镜像
+仓库复制失败也不算发布完成。不要通过移动 tag 修复发布。核验与同步回 main
+完成后才能关闭版本 milestone。
+
+发布机制改动会触发 PR 演练，也可通过 `workflow_dispatch` 对指定分支演练。
+两种模式都只构建镜像、不推送，并运行四平台 snapshot，不发布二进制或 Homebrew。
+只有 tag push 能发布。系统日志以 `if: always()` 上传，详见 `testing.zh.md`。
+演练耗时不包含 registry 上传和镜像仓库复制，暖缓存测试还需要长期分支先成功写入缓存。
 
 ## Agent 性能门禁
 

--- a/web/content/docs/development/rules/testing.md
+++ b/web/content/docs/development/rules/testing.md
@@ -19,11 +19,27 @@ mise run eval:loop                        # Harbor behavior evaluation
 
 `mise run perf` runs both `test/e2e/perf/render.spec.ts` and `load.spec.ts`, with the testbed's embedded fake model. `mise run testbed:start` and `mise run testbed:stop` remain available for manual API and browser exploration. `test:web`, coverage, race, and `eval:*` tasks remain specialized commands rather than additional functional test layers.
 
-The required PR Test check runs `mise run test:coverage:race`: it builds the
-server, runs package tests with race detection and coverage, then runs the
-subprocess system suite without race instrumentation. Frontend tests run in a
-separate step. System logs are uploaded even on failure, so Linux process
-regressions are checked before tagging rather than first discovered by release CI.
+The required PR `Test` check joins two parallel jobs. `test:coverage:race`
+runs package race/coverage and frontend tests; `test:system` builds fresh embedded
+assets and runs the subprocess journeys without race instrumentation. Failure,
+cancellation, or skipping either job fails the required check. Both jobs require
+working Linux sandbox namespaces and packaged resources. System logs are uploaded
+on failure. `test:packages` runs the non-race package/Web lane in release CI;
+`mise run test` remains the complete local suite.
+
+Go build caches are shared by compilation mode (plain, race, Windows). Successful
+main and maintained-release branch jobs save a new commit-keyed snapshot; PR and
+tag jobs restore compatible snapshots without saving duplicate object caches.
+The system job writes the plain cache, the package job writes race, and Windows
+writes its own cache. Dependency downloads retain their immutable keys. PR caches
+cannot warm other PRs, so latency should be compared separately for cache hits and
+misses. A new Go version still requires a cold compilation.
+
+The Docker check builds directly from a clean checkout, with generation owned by
+the Dockerfile. main warms the registry builder cache used by PRs and release
+amd64 builds. PRs export intermediate layers to their GHA cache, and superseded PR
+image runs are cancelled. Cache mounts inside Docker remain local to the builder;
+the layer cache does not promise persistent Go or pnpm mount contents.
 
 ## Where to write tests
 

--- a/web/content/docs/development/rules/testing.zh.md
+++ b/web/content/docs/development/rules/testing.zh.md
@@ -19,9 +19,23 @@ mise run eval:loop                        # Harbor 行为评估
 
 `mise run perf` 一次运行 `test/e2e/perf/render.spec.ts` 和 `load.spec.ts`，使用 testbed 内嵌的假模型。`mise run testbed:start` 和 `mise run testbed:stop` 保留给手工 API/浏览器探索。`test:web`、coverage、race 和 `eval:*` 是专门命令，不是额外的功能测试层。
 
-PR 必须通过的 Test 检查运行 `mise run test:coverage:race`：先构建服务端，运行
-带 race 检测和覆盖率的包测试，再运行不带 race 的真实进程系统测试。前端测试
-单独执行。系统日志在失败时也会上传，Linux 进程回归必须在打 tag 前接受检查。
+PR 必须通过的 `Test` 检查汇总两条并行通道。`test:coverage:race` 运行包内
+race/coverage 和前端测试；`test:system` 构建最新内嵌资源，再运行不带 race 的
+子进程系统测试。任一通道失败、取消或跳过，必需检查都会失败。两条通道都强制
+检查 Linux sandbox namespace 和打包资源，系统日志在失败时也会上传。
+`test:packages` 用于 release 的非 race 包测试和前端通道；本地完整测试入口仍是
+`mise run test`。
+
+Go 编译缓存按普通编译、race、Windows 共享。main 和维护发布分支的成功任务
+保存带提交标识的新快照；PR 和 tag 只恢复兼容快照，不重复保存大体积对象缓存。
+system 任务负责写普通缓存，包测试任务写 race，Windows 写自身缓存。依赖下载
+仍按不可变输入缓存。PR 缓存不能为其他 PR 预热，所以耗时需要区分命中和未命中；
+升级 Go 版本仍需冷编译。
+
+Docker 检查直接从干净 checkout 构建，由 Dockerfile 负责生成代码。main 为 PR
+和 release amd64 构建预热 registry builder 缓存；PR 将中间层导出到自身的 GHA
+缓存，并取消被后续提交替代的镜像运行。Docker 内部 cache mount 仍属于当前
+builder，不能把层缓存命中当成 Go 或 pnpm mount 内容已持久化。
 
 ## 写在哪
 


### PR DESCRIPTION
## What

Reduce PR and release CI duplication while preserving the required Test check and release publication gates. PR package race/Web and Linux subprocess tests run independently; tagged releases build four-platform GoReleaser artifacts once and promote both main and sandbox images only after validation succeeds.

## Why

The v0.68.1 release took 25m26s. Its two test lanes both ran the complete suite, and GoReleaser rebuilt the four-platform snapshot before publishing. PR #1264 took 17m18s with no race build cache, compared with #1263's 8m29s with a restored cache. The old standalone sandbox tag workflow could publish even when the main release failed.

## How

- Retain `Test` as an always-running aggregate that requires both package and system jobs to succeed. Preserve package race/coverage, frontend tests, Linux sandbox/SPA/Xberg requirements, diagnostics and Windows portability.
- Prepare generation and embedded assets through each mise task graph, avoiding separate repeated workflow preparation. Keep the complete local `mise run test` contract.
- Share Go objects by plain/race/Windows compilation mode and rotate successful branch snapshots by commit. PR/tag jobs restore only; system, package and Windows jobs own branch cache writes. Dependency download caches remain immutable.
- Build PR Docker images from a clean checkout, export intermediate builder layers, warm the shared amd64 registry cache on main, and cancel superseded PR image runs.
- Run digest-only main/sandbox image candidates alongside release validation. Wait for every validation and image build before the pinned GoReleaser builds and publishes all four platforms once, then publish both images' aliases. Retain local pre-cut snapshots and add non-publishing PR/manual release rehearsals.
- Copy to the mirror once, then create remaining aliases within the destination repository. Preserve RC exclusions for stable aliases and Homebrew. Update bilingual cache, workflow, failure and retry documentation.

Deliberate limits: GoReleaser remains the publisher; this does not implement a custom artifact uploader, buy larger runners, or remove tests. Cross-service publication is not transactional and failed runs may leave digest-only candidates. Docker cache mounts remain builder-local. Release-image binary reuse and test-case micro-optimization are deferred until the simpler changes are measured.

## Test

Final head `c8ba61d99b6538b8f366a4083e31996bf5893043` passed all hosted checks and the non-publishing release rehearsal. Normal check job durations: package race/Web 5m51s, Linux system 3m20s, Format 2m13s, Windows 2m11s, aggregate Test 3s, Docker 6m49s. The Format/Test workflow job span was 8m18s including scheduling gaps, so the longest-job time must not be presented as end-to-end PR latency.

From workflow creation to completion, Format/Test took 8m32s and the release rehearsal took 15m29s. Final rehearsal job span was 15m13s including scheduling gaps: amd64 image 4m48s, arm64 image 5m40s, sandbox candidate 6m29s, GoReleaser 6m12s. All four platform archives/Linux packages built and the host archive check passed; publishing was skipped. arm64 dropped from 10m03s to 5m40s after removing its unused cache export; the first run's export alone took 268.7s. These are individual hosted runs, not medians or live-release timing.

Final runs: [PR checks](https://github.com/CherryHQ/stella/actions/runs/33944829111), [Docker](https://github.com/CherryHQ/stella/actions/runs/33944829104), [sandbox](https://github.com/CherryHQ/stella/actions/runs/33944829107), [release rehearsal](https://github.com/CherryHQ/stella/actions/runs/33944829213).

- Focused publishing-policy tests passed: all 16 success/failure/cancelled/skipped combinations for the actual required-check command, release prerequisites, tag-only publication, and non-pushing rehearsal settings.
- Mirror helper tests passed: one remote copy, subsequent destination-local aliases, single-tag RC path, missing-argument rejection, and no alias creation after copy failure.
- YAML parsing with duplicate-key detection and job dependency validation passed.
- Full local `mise run format && mise run build && mise run test`: passed, including 37 frontend test files / 344 tests and subprocess system tests (96.387s). `mise run release:check`, focused shellcheck, and final formatting checks also passed. Existing modernize conflicting-edit and one frontend type warning remain unchanged.
- First commit `df0bc4ae0` hosted ordinary PR checks passed: package race/Web 5m56s (37 files / 344 frontend tests), Linux system 3m50s, Format 2m45s, Windows 2m04s, aggregate Test 3s, and Docker 7m15s. Race restored the compatible legacy branch cache; this is one warm-cache sample, not a cold-cache or median claim. Run: https://github.com/CherryHQ/stella/actions/runs/33943763207 . Docker: https://github.com/CherryHQ/stella/actions/runs/33943763174 .
- First commit `df0bc4ae0` non-publishing release rehearsal passed: both image architectures, sandbox, Go/Web, system and four-platform snapshot (494s); publication jobs/steps were skipped. Run: https://github.com/CherryHQ/stella/actions/runs/33943763342 .
- Follow-up `c8ba61d99` removes rehearsal GHA cache exports: arm64 spent 268.7s exporting a cache that was never restored. Formal tag registry cache writes remain unchanged. The follow-up passed full local format/build/test again (system 107.259s) and the publishing-policy regression. Final hosted checks passed as recorded above; first-commit results are retained as comparison measurements, not substituted for final-head validation.

Performance targets are estimates, not measured improvements: normal warm PR checks about 6–8 minutes, cold PR checks 10–13 minutes, complete release 12–16 minutes. This workflow-changing PR also runs the heavier release rehearsal; its total time is not the normal business-PR baseline. Branch cache writing and registry/mirror publication need post-merge or next-release measurements; the rehearsal never publishes a test release.

## Refs

Closes #1265

Baseline: https://github.com/CherryHQ/stella/actions/runs/33941588424 and https://github.com/CherryHQ/stella/actions/runs/33940344208
Previous release repair: #1262, #1263, #1264

## Checklist

- [x] The PR links the implementation issue #1265.
- [x] Focused tests cover required-check failure propagation and image promotion behavior.
- [x] Relevant English and Chinese testing/release documentation is updated.
- [x] I ran `mise run format && mise run build && mise run test` successfully.
- [x] Agent behavior is unchanged; no Terminal-Bench evaluation or agent-performance claim applies.
- [x] CI DAG and image alias behavior are outside Terminal-Bench; shell policy tests and a hosted non-publishing packaging rehearsal cover these seams. Live mirror transfer remains unmeasured.
- [x] Baseline CI measurements remain recorded; no historical result is relabeled as a candidate result.
