### PR TITLE
⚡ ci: remove release rehearsals and clarify task boundaries

### DIFF
--- a/.github/scripts/verify-ci-policy_test.sh
+++ b/.github/scripts/verify-ci-policy_test.sh
@@ -23,16 +23,14 @@ done
 # All validation and image candidates must succeed before GoReleaser can publish.
 test "$(yq '.jobs.goreleaser.needs | sort | join(",")' "$release")" = 'docker,quality,sandbox,system,tests'
 test "$(yq '.jobs.merge.needs | sort | join(",")' "$release")" = 'docker,goreleaser,sandbox'
-test "$(yq '.jobs.source.steps[] | select(.name == "Verify tag identity and release branch") | .if' "$release")" = "github.event_name == 'push'"
+test "$(yq '.on | keys | join(",")' "$release")" = push
 test "$(yq '.on.push | keys | join(",")' "$release")" = tags
-test "$(yq '.jobs.goreleaser.steps[] | select(.name == "Run GoReleaser") | .if' "$release")" = "github.event_name == 'push'"
-test "$(yq '.jobs.merge.if' "$release")" = "github.event_name == 'push'"
 test "$(yq '.on.push.tags' "$sandbox")" = null
 test "$(yq '.jobs.sandbox.with.candidate' "$release")" = true
 
-# Read-only rehearsals must not push candidate images, even on workflow_dispatch.
+# Release runs only on tags; standalone sandbox PR builds must remain read-only.
 push_condition="\${{ github.event_name == 'push' }}"
-test "$(yq '.jobs.docker.steps[] | select(.id == "build") | .with.push' "$release")" = "$push_condition"
+test "$(yq '.jobs.docker.steps[] | select(.id == "build") | .with.push' "$release")" = true
 test "$(yq '.jobs.build.steps[] | select(.id == "build") | .with.push' "$sandbox")" = "$push_condition"
 
 echo 'CI policy: aggregate outcomes and release publication gates passed'

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -44,11 +44,8 @@ jobs:
       - name: Generate code and check drift
         run: mise run generate:check
 
-      - name: Test release source policy
-        run: |
-          bash .github/scripts/verify-release-source_test.sh
-          bash .github/scripts/verify-ci-policy_test.sh
-          bash .github/scripts/copy-image-tags_test.sh
+      - name: Test CI and release policy
+        run: mise run test:ci-policy
 
       - name: Run pre-commit hooks
         run: prek run --all-files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,24 +3,9 @@ name: Release
 on:
   push:
     tags: ["v*.*.*"]
-  # Changes to publication mechanics get a full, non-publishing rehearsal.
-  pull_request:
-    paths:
-      - ".github/workflows/release.yml"
-      - ".github/workflows/sandbox-docker.yml"
-      - ".github/actions/toolchain-caches/**"
-      - ".github/scripts/*image*"
-      - ".github/scripts/*release*"
-      - ".goreleaser.yaml"
-      - "Dockerfile"
-      - "plugins/sandbox/docker/Dockerfile"
-      - ".mise/tasks/release/**"
-      - "mise.toml"
-  workflow_dispatch:
 
 concurrency:
-  group: release-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: release-${{ github.ref }}
 
 permissions:
   contents: read
@@ -48,7 +33,6 @@ jobs:
           fetch-depth: 0
 
       - name: Verify tag identity and release branch
-        if: github.event_name == 'push'
         env:
           EVENT_REF: ${{ github.ref }}
           EVENT_SHA: ${{ github.sha }}
@@ -96,11 +80,8 @@ jobs:
       - name: Generate code and check drift
         run: mise run generate:check
 
-      - name: Test release source policy
-        run: |
-          bash .github/scripts/verify-release-source_test.sh
-          bash .github/scripts/verify-ci-policy_test.sh
-          bash .github/scripts/copy-image-tags_test.sh
+      - name: Test CI and release policy
+        run: mise run test:ci-policy
 
       - name: Check formatting and lint
         run: |
@@ -243,18 +224,12 @@ jobs:
       - name: Check release configuration
         run: mise run release:check
 
-      # Formal releases build all four targets once, after every validation and
-      # image build succeeded. PRs exercise the same configuration without writes.
+      # Build all four targets once, after validation and image builds succeed.
       - name: Run GoReleaser
-        if: github.event_name == 'push'
-        run: mise exec -- goreleaser release --clean
+        run: mise run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-
-      - name: Rehearse four-platform release without publishing
-        if: github.event_name != 'push'
-        run: mise run release:snapshot
 
   docker:
     name: Docker Release
@@ -289,7 +264,6 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log into GitHub Container Registry
-        if: github.event_name == 'push'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -301,31 +275,27 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          push: ${{ github.event_name == 'push' }}
+          push: true
           platforms: ${{ matrix.platform }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ github.ref_name }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ matrix.suffix }}
-          # Rehearsals only read the published builder cache. Exporting all
-          # intermediate layers to a PR-only cache cost 4m29s on arm64.
-          cache-to: ${{ github.event_name == 'push' && format('type=registry,ref={0}/{1}:buildcache-{2},mode=max', env.REGISTRY, env.IMAGE_NAME, matrix.suffix) || '' }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ matrix.suffix }},mode=max
           build-args: |
             VERSION=${{ github.ref_name }}
           secrets: |
             github_token=${{ secrets.GITHUB_TOKEN }}
-          outputs: ${{ github.event_name == 'push' && format('type=image,name={0}/{1},push-by-digest=true,name-canonical=true,push=true', env.REGISTRY, env.IMAGE_NAME) || '' }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
-        if: github.event_name == 'push'
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        if: github.event_name == 'push'
         uses: actions/upload-artifact@v7
         with:
           name: digests-${{ matrix.suffix }}
@@ -337,7 +307,6 @@ jobs:
     name: Merge Docker Manifests
     runs-on: ubuntu-latest
     needs: [goreleaser, docker, sandbox]
-    if: github.event_name == 'push'
 
     permissions:
       contents: read

--- a/.mise/tasks/release/snapshot
+++ b/.mise/tasks/release/snapshot
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#MISE description="Create host-only snapshot build and verify single-binary archive"
+#MISE description="Build four-platform packages without publishing and check the host archive"
 set -euo pipefail
 
 goreleaser release --snapshot --clean --skip=publish

--- a/.mise/tasks/release/validate
+++ b/.mise/tasks/release/validate
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#MISE description="Validate a local release in order: format, build, test, check, snapshot"
+set -euo pipefail
+
+mise run format
+# Refresh the SPA before test builds stellad and compiles its tests.
+mise run build:embedded
+STELLA_TEST_REQUIRE_SPA=1 mise run test
+mise run release:check
+mise run release:snapshot

--- a/.mise/tasks/test/ci-policy
+++ b/.mise/tasks/test/ci-policy
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#MISE description="Test required CI checks, release source policy, and image publishing"
+set -euo pipefail
+
+bash .github/scripts/verify-release-source_test.sh
+bash .github/scripts/verify-ci-policy_test.sh
+bash .github/scripts/copy-image-tags_test.sh

--- a/.mise/tasks/test/coverage/race
+++ b/.mise/tasks/test/coverage/race
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#MISE description="Run package race/coverage and frontend tests (CI)"
+#MISE depends=["generate:check", "build:embedded"]
+set -euo pipefail
+
+# go:embed must not race a still-running SPA build.
+go run ./cmd/stellad postgres download
+go test -race -coverprofile=coverage.out ./...
+mise run test:web

--- a/.mise/tasks/test/packages
+++ b/.mise/tasks/test/packages
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#MISE description="Run package Go and frontend tests without system journeys (CI)"
+#MISE depends=["generate:check", "build:embedded"]
+set -euo pipefail
+
+go run ./cmd/stellad postgres download
+go test ./...
+mise run test:web

--- a/mise.toml
+++ b/mise.toml
@@ -178,7 +178,7 @@ done
 # must exist for the package to compile, and their absence used to turn the
 # embedded-tool tests into silent skips.
 [tasks.test]
-description = "Run Go tests and the subprocess system suite"
+description = "Run package Go, frontend, and subprocess system tests"
 depends = ["pg:runtime:download", "build"]
 run = """
 go test ./...
@@ -192,33 +192,14 @@ dir = "web"
 run = "vp test run"
 
 [tasks."test:coverage"]
-description = "Run tests with coverage report"
+description = "Run package Go tests with a coverage report"
 depends = ["pg:runtime:download"]
 run = "go test -coverprofile=coverage.out ./..."
 
 [tasks."test:race"]
-description = "Run all tests with race detection (CI)"
+description = "Run package Go tests with race detection"
 depends = ["pg:runtime:download"]
 run = "go test -race ./..."
-
-[tasks."test:coverage:race"]
-description = "Run package race/coverage and frontend tests (CI)"
-depends = ["generate:check", "build:embedded"]
-run = """
-# go:embed must not race a still-running SPA build.
-go run ./cmd/stellad postgres download
-go test -race -coverprofile=coverage.out ./...
-mise run test:web
-"""
-
-[tasks."test:packages"]
-description = "Run package Go and frontend tests without repeating system journeys (CI)"
-depends = ["generate:check", "build:embedded"]
-run = """
-go run ./cmd/stellad postgres download
-go test ./...
-mise run test:web
-"""
 
 [tasks."test:e2e"]
 description = "Run all Playwright end-to-end specs against a disposable testbed"
@@ -295,31 +276,12 @@ run = 'goose -dir internal/db/migrations postgres "$STELLA_DATABASE_URL" status'
 # ============================================================================
 
 [tasks.release]
-description = "Create a stable or release-candidate build with GoReleaser"
+description = "Build and publish a stable or release-candidate tag with GoReleaser"
 run = "goreleaser release --clean"
 
 [tasks."release:check"]
 description = "Validate GoReleaser configuration"
 run = "goreleaser check"
-
-[tasks."release:validate"]
-description = "Full local pre-release gate, run strictly in order: format, build, tests, then release checks"
-# Explicit sequential mise-run chain (set -e aborts on first failure) rather than
-# `depends`, whose members may run in parallel; correctness over avoiding duplicate
-# builds.
-run = """
-set -e
-mise run format
-mise run build
-# The SPA must exist before `test` compiles the test binaries: go:embed
-# snapshots web/static/dist at compile time, and STELLA_TEST_REQUIRE_SPA makes
-# the PWA build contract a failure instead of a skip. A stale dist here is what
-# caught the missing service worker during the v0.61.0 release.
-mise run build:web
-STELLA_TEST_REQUIRE_SPA=1 mise run test
-mise run release:check
-mise run release:snapshot
-"""
 
 # ============================================================================
 # Deploy

--- a/web/content/docs/development/rules/release.md
+++ b/web/content/docs/development/rules/release.md
@@ -204,8 +204,10 @@ Apply to both changelog files:
 
 ## Validate and Test
 
-Run the full pre-cut gate — it executes, strictly in order, `format` → `build` →
-`build:web` → `test` → `release:check` → `release:snapshot`:
+Run the full pre-cut gate in order: `format` → `build:embedded` → `test` →
+`release:check` → `release:snapshot`. `build:embedded` refreshes generated code
+and the SPA; `test` then builds the server and runs Go, frontend, and system
+tests with `STELLA_TEST_REQUIRE_SPA=1`.
 
 ```bash
 VERSION=X.Y.Z # or X.Y.Z-rc.N
@@ -232,12 +234,24 @@ permits publishing aliases; a failed mirror copy does not make the release
 complete. Do not retag to repair publication. Finish verification and sync-back
 before closing the milestone.
 
-Changes to release mechanics trigger a PR rehearsal, and `workflow_dispatch`
-can rehearse a selected branch. Both modes build images without pushing and run
-the four-platform snapshot instead of publishing binaries or Homebrew. Only a
-tag-push event can publish. Hosted system logs are uploaded with `if: always()`;
-see `testing.md`. Rehearsal timing does not measure registry uploads or mirror
-transfer, and warm-cache timing requires a successful branch cache writer first.
+The Release workflow runs only for `v*.*.*` tag pushes. PRs use the ordinary
+checks described in [Testing](./testing); there is no PR or manual release
+rehearsal workflow. Changes to CI policy are checked by `mise run test:ci-policy`
+in both the Format job and release quality job. System logs are uploaded even
+on failure.
+
+Use `mise tasks` to inspect the available commands:
+
+| Task               | Purpose                                                                                                                                                            |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `release:check`    | Validate GoReleaser configuration without building or publishing.                                                                                                  |
+| `release:snapshot` | Build Linux/macOS × amd64/arm64 archives and Linux packages without publishing; verify the host archive contains `stellad`. Requires one of those supported hosts. |
+| `release:validate` | Run the complete local pre-cut gate above, stopping at the first failure.                                                                                          |
+| `release`          | Build and publish through GoReleaser. Tag CI calls this after source, quality, test, and image gates; it does not run those gates itself.                          |
+
+The local snapshot remains a release validation tool. Its duration excludes
+registry uploads and mirror transfer. Cache timing must distinguish restored
+branch caches from cold builds.
 
 ## Agent Performance Gate
 

--- a/web/content/docs/development/rules/release.zh.md
+++ b/web/content/docs/development/rules/release.zh.md
@@ -135,7 +135,9 @@ gh pr list --state merged --base "${RELEASE_BRANCH:-main}" --search "merged:>=$(
 
 ## 验证与测试
 
-运行完整发布前门禁。它严格按 `format` → `build` → `build:web` → `test` → `release:check` → `release:snapshot` 执行：
+运行完整发布前门禁，顺序为 `format` → `build:embedded` → `test` →
+`release:check` → `release:snapshot`。`build:embedded` 更新生成代码和 SPA，
+随后 `test` 构建服务端，并在 `STELLA_TEST_REQUIRE_SPA=1` 下运行 Go、前端和系统测试。
 
 ```bash
 VERSION=X.Y.Z # 或 X.Y.Z-rc.N
@@ -158,10 +160,21 @@ GitHub、Homebrew、GHCR 和镜像仓库之间没有事务。发布步骤失败�
 仓库复制失败也不算发布完成。不要通过移动 tag 修复发布。核验与同步回 main
 完成后才能关闭版本 milestone。
 
-发布机制改动会触发 PR 演练，也可通过 `workflow_dispatch` 对指定分支演练。
-两种模式都只构建镜像、不推送，并运行四平台 snapshot，不发布二进制或 Homebrew。
-只有 tag push 能发布。系统日志以 `if: always()` 上传，详见 `testing.zh.md`。
-演练耗时不包含 registry 上传和镜像仓库复制，暖缓存测试还需要长期分支先成功写入缓存。
+Release 工作流只响应 `v*.*.*` tag push。PR 运行[测试规则](./testing)中的常规
+检查，不提供 PR 或手动 release 演练入口。Format job 和 release quality job 都通过
+`mise run test:ci-policy` 检查 CI 策略。系统日志在失败时也会上传。
+
+用 `mise tasks` 查看可用命令：
+
+| 任务               | 用途                                                                                                                         |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `release:check`    | 检查 GoReleaser 配置，不构建、不发布。                                                                                       |
+| `release:snapshot` | 构建 Linux/macOS × amd64/arm64 归档和 Linux 安装包，不发布；检查宿主平台归档包含 `stellad`。必须在其中一种受支持的平台运行。 |
+| `release:validate` | 顺序运行上述完整本地发布前门禁，任一步失败就停止。                                                                           |
+| `release`          | 通过 GoReleaser 构建并发布。tag CI 在来源、质量、测试和镜像门禁通过后调用；此任务本身不执行这些门禁。                        |
+
+本地 snapshot 仍用于发布验证。其耗时不包含 registry 上传和镜像仓库复制，缓存
+计时需要区分恢复了分支缓存的构建与冷构建。
 
 ## Agent 性能门禁
 

--- a/web/content/docs/development/rules/testing.md
+++ b/web/content/docs/development/rules/testing.md
@@ -27,6 +27,18 @@ working Linux sandbox namespaces and packaged resources. System logs are uploade
 on failure. `test:packages` runs the non-race package/Web lane in release CI;
 `mise run test` remains the complete local suite.
 
+CI lane tasks (`test:packages`, `test:coverage:race`, `test:system`) require a
+clean checkout: their `generate:check` dependency rejects tracked or untracked
+changes. Use `mise run test` while editing locally. `test:race` and
+`test:coverage` run only package Go tests; they do not include frontend or
+subprocess system tests.
+
+`mise run test:ci-policy` checks aggregate job outcomes, tag-only release
+triggers, release source validation, and image promotion without building the
+application. Both CI workflows call this task. The CI lane and local release
+validation scripts live in `.mise/tasks/`, use Bash strict mode, and are included in
+`mise run lint:shell`. Use `mise tasks` for task names and descriptions.
+
 Go build caches are shared by compilation mode (plain, race, Windows). Successful
 main and maintained-release branch jobs save a new commit-keyed snapshot; PR and
 tag jobs restore compatible snapshots without saving duplicate object caches.

--- a/web/content/docs/development/rules/testing.zh.md
+++ b/web/content/docs/development/rules/testing.zh.md
@@ -26,6 +26,16 @@ race/coverage 和前端测试；`test:system` 构建最新内嵌资源，再运�
 `test:packages` 用于 release 的非 race 包测试和前端通道；本地完整测试入口仍是
 `mise run test`。
 
+CI 通道任务（`test:packages`、`test:coverage:race`、`test:system`）要求干净
+checkout：它们依赖的 `generate:check` 会拒绝已跟踪或未跟踪的改动。本地编辑时
+使用 `mise run test`。`test:race` 和 `test:coverage` 只运行包内 Go 测试，不包含
+前端或子进程系统测试。
+
+`mise run test:ci-policy` 无需构建应用，即可检查汇总 job 的结果、仅 tag 触发
+release 的限制、发布来源和镜像发布策略。两个 CI 工作流都调用此任务。CI 通道
+和本地发布校验脚本放在 `.mise/tasks/`，使用 Bash strict mode，并纳入
+`mise run lint:shell`。用 `mise tasks` 查看任务名称和说明。
+
 Go 编译缓存按普通编译、race、Windows 共享。main 和维护发布分支的成功任务
 保存带提交标识的新快照；PR 和 tag 只恢复兼容快照，不重复保存大体积对象缓存。
 system 任务负责写普通缓存，包测试任务写 race，Windows 写自身缓存。依赖下载


### PR DESCRIPTION
## What

Run Release only on version-tag pushes. Remove automatic PR and manual release rehearsals, and clarify the mise task boundaries and bilingual release/testing documentation.

## Why

#1266 added a release rehearsal path filter covering all of `mise.toml`. #1270 only changed generated-file checks in that file, yet triggered the full release pipeline alongside normal PR CI. Its first rehearsal took 12m45s. The additional builds consume runners and repeat checks without being required for ordinary PRs.

## How

- Remove `pull_request` and `workflow_dispatch` from Release, its snapshot step, and event branches used only by rehearsals. Keep source validation, test/image prerequisites, and post-validation publication ordering.
- Add a regression assertion that Release has only a tag-push trigger; retain aggregate-result and sandbox PR no-push policy checks.
- Share the existing three CI/release policy scripts through `mise run test:ci-policy` in both workflows.
- Move the multi-command package-test lanes and local release-validation script into executable mise file tasks with Bash strict mode and shellcheck coverage. Preserve their task names and CI dependencies.
- Refresh embedded assets before the local full test task builds the server, removing an earlier redundant server build. Preserve the SPA requirement and stop at the first failed stage.
- Correct task descriptions and document local versus CI testing, four-platform snapshots, and the publishing behavior of `mise run release`. Local `release:snapshot` remains a pre-cut check.

## Test

Validated commit `9bc1592c5` locally:

- `mise run format && mise run build && mise run test`: passed. Frontend: 37 files / 344 tests; subprocess system suite: 95.156s. Existing modernize conflicting-edit warnings and one frontend type warning remain; no unrelated files changed.
- `mise run test:ci-policy`, `mise run lint:shell`, and `mise run release:check`: passed. GoReleaser reports the existing Homebrew brews deprecation warning.
- Mutation checks confirmed the policy test rejects reintroduced PR, manual, and branch-push Release triggers.
- A stubbed task-runner check verified the local release-validation order, `STELLA_TEST_REQUIRE_SPA=1`, and stop-on-failure at each of its five stages.
- Workflow YAML parsing and job dependency references passed. Mise task discovery and dry runs resolved both moved CI lanes with their existing dependencies. `git diff --check` passed.

Four-platform snapshot and actual publishing were not run in this change. The snapshot command is unchanged apart from its description; hosted publication, registry transfer, and next-tag execution remain unverified. No latency improvement is claimed from local tests.

## Refs

Refs #1265. Follow-up correction to #1266; reproduction in #1270.

Reproduction run: https://github.com/CherryHQ/stella/actions/runs/33948998923

## Checklist

- [x] The PR links a GitHub issue, or states why the fix is small enough not to need one. Follow-up to #1265.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed. Trigger policy regression and task-order/failure checks are described above.
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed. Both release and testing rules are updated.
- [x] I ran `mise run format && mise run build && mise run test`.
- [x] If this changes agent behavior (tools, prompts, the runner loop): I included eval evidence with both jobs, commits, tier, k, host, and model, or stated why it is not applicable. Not applicable: CI/task orchestration only.
- [x] If the change touches a surface no eval task exercises (pixel understanding, document extraction, CRLF fidelity, non-UTF-8, binary handling): I said so, and named the tests that cover it instead. CI triggers and task sequencing are outside Terminal-Bench; policy and shell checks cover them. Packaging implementation is unchanged, and no fresh cross-platform packaging result is claimed.
- [x] Any earlier measurement this PR invalidates is marked superseded with its reason, not deleted. Historical #1266 rehearsal timings remain valid for that workflow; its PR/manual rehearsal path is removed here and those timings do not describe this PR's ordinary CI. No replacement latency measurement is claimed.
