### PR TITLE
docs: prepare v0.68.2 release

### DIFF
--- a/deploy/helm/stella/Chart.yaml
+++ b/deploy/helm/stella/Chart.yaml
@@ -8,7 +8,7 @@ version: 0.1.5
 # against. It is NOT the default image tag: the chart defaults image.tag to
 # "latest" (see stella.image / values.yaml) so a fresh install tracks the newest
 # published release. Pin image.tag or image.digest for reproducible deploys.
-appVersion: "v0.68.1"
+appVersion: "v0.68.2"
 home: https://stella.cherryin.com
 sources:
   - https://github.com/CherryHQ/stella

--- a/web/content/docs/changelog.mdx
+++ b/web/content/docs/changelog.mdx
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.68.2] - 2026-09-07
+
+### 🐛 Bug Fixes
+
+- Keep completed Feishu replies focused on the answer. Thinking and tool progress remain visible while generating, then disappear instead of producing extra completed cards. Long answers still split normally. ([#1278](https://github.com/CherryHQ/stella/pull/1278))
+
+**Full Changelog**: [v0.68.1...v0.68.2](https://github.com/CherryHQ/stella/compare/v0.68.1...v0.68.2)
+
 ## [0.68.1] - 2026-09-05
 
 This is the first complete stable release of the 0.68 line. The v0.68.0 attempt stopped at the system-test gate after publishing only its sandbox image.

--- a/web/content/docs/changelog.zh.mdx
+++ b/web/content/docs/changelog.zh.mdx
@@ -11,6 +11,14 @@ icon: History
 
 ## [Unreleased]
 
+## [0.68.2] - 2026-09-07
+
+### 🐛 Bug Fixes
+
+- 飞书回复完成后只保留回答正文，思考和工具进度仅在生成过程中展示，不再产生额外的已完成卡片。长正文仍正常拆分。 ([#1278](https://github.com/CherryHQ/stella/pull/1278))
+
+**Full Changelog**: [v0.68.1...v0.68.2](https://github.com/CherryHQ/stella/compare/v0.68.1...v0.68.2)
+
 ## [0.68.1] - 2026-09-05
 
 这是 0.68 系列首次完整的稳定发布。v0.68.0 在系统测试门禁失败，仅发布了 sandbox 镜像。

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.68.1",
+  "version": "0.68.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What

Prepare v0.68.2 on release/v0.68. This patch contains only the Feishu final-card fix in #1278: thinking/tool progress remains visible during generation but does not spill into completed reply cards.

## Why

Long progress timelines could produce many extra cards after a short answer. Publish the fix as a patch on the maintained 0.68 line without bringing newer main work into the release.

## How

Set the Web version to 0.68.2, Helm appVersion to v0.68.2, and add matching English/Chinese changelogs. Chart templates are unchanged, so the chart version stays 0.1.5. Published tag v0.68.2 at 60b5f67c98b728b810a1f339dd372a9551d8ccf6. All release jobs succeeded, including both Docker architectures and mirror promotion. Sync-back #1281 merged into main at 14c363023f1470a14a91c5c6edf4c4f18b577e96; all nine relevant files match the published tag.

## Test

- `mise run release:validate`: passed in this checkout, including format, build, build:web, Go/web/system tests, GoReleaser configuration validation, and a release snapshot.
- Snapshot built linux/darwin × amd64/arm64 binaries and verified that the host archive contains stellad.
- Focused Feishu regression coverage and the full suite passed for #1278. No live Feishu smoke test was run.
- Published macOS arm64 archive checksum verified; its stellad version command returned 0.68.2. Homebrew is at 0.68.2. Docker latest and v0.68.2 both resolve to sha256:a0fbfd70292433857ee1110ad2f7d784963c6882ec4432252829b6fb9d4eeaf5 with linux/amd64 and linux/arm64 manifests.
- Terminal-Bench not run: this is a channel-presentation-only patch with no tools, prompts, model inputs, sandbox, or runner changes. No agent-performance improvement is claimed over v0.68.1.

## Refs

Closes #1279

Published release: https://github.com/CherryHQ/stella/releases/tag/v0.68.2

Successful release workflow: https://github.com/CherryHQ/stella/actions/runs/34120379434

Merged sync-back: #1281

Includes #1278. Release scope: v0.68.1 to v0.68.2, only the Feishu final-card fix and release metadata.

## Checklist

- [x] The PR links a GitHub issue, or states why the fix is small enough not to need one.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed. Covered in #1278; this PR adds release metadata only.
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed.
- [x] I ran `mise run format && mise run build && mise run test`. Included in release:validate, with build:web before tests.
- [x] If this changes agent behavior (tools, prompts, the runner loop): I included eval evidence with both jobs, commits, tier, k, host, and model, or stated why it is not applicable. Not applicable; explanation above.
- [x] If the change touches a surface no eval task exercises (pixel understanding, document extraction, CRLF fidelity, non-UTF-8, binary handling): I said so, and named the tests that cover it instead. Feishu cards are covered by TestStreamFinalCardsExcludeProgress, not Harbor.
- [x] Any earlier measurement this PR invalidates is marked superseded with its reason, not deleted. No earlier measurements invalidated.
