### PR TITLE
treewide: publish immutable dev images

### DIFF
--- a/.github/workflows/dev-images.yml
+++ b/.github/workflows/dev-images.yml
@@ -1,0 +1,95 @@
+name: Publish Dev Images
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: cherryhq/stella
+  SANDBOX_IMAGE_NAME: cherryhq/stella-sandbox
+
+jobs:
+  publish:
+    name: Publish immutable dev images
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+
+      - name: Set up mise
+        uses: jdx/mise-action@v4
+        with:
+          version: "2026.9.2"
+          experimental: true
+          install: true
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Restore toolchain caches
+        uses: ./.github/actions/toolchain-caches
+        with:
+          scope: plain
+
+      - name: Generate source artifacts
+        run: mise run generate
+
+      - name: Resolve builtin bundle revision
+        id: builtin-bundle
+        run: echo "revision=$(go run ./cmd/stellad system-bundle revision)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log into GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Stella server
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=dev-${{ github.sha }}
+          build-args: |
+            VERSION=${{ github.sha }}
+          cache-from: type=gha,scope=stella-dev-server
+          cache-to: type=gha,scope=stella-dev-server,mode=max
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Kubernetes sandbox
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: plugins/sandbox/docker/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.SANDBOX_IMAGE_NAME }}:dev-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=dev-${{ github.sha }}
+          build-args: |
+            VERSION=${{ github.sha }}
+            BUILTIN_BUNDLE_REVISION=${{ steps.builtin-bundle.outputs.revision }}
+          cache-from: type=gha,scope=stella-dev-sandbox
+          cache-to: type=gha,scope=stella-dev-sandbox,mode=max
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Add a manually triggered GitHub Actions workflow that publishes immutable linux/amd64 dev images for the Stella server and native Kubernetes sandbox.

## Why

The native Kubernetes backend is on main, but the normal main Docker workflow intentionally does not publish a server image. TKE GitOps needs a reproducible image pair with the same source commit and builtin bundle.

## How

The workflow uses GitHub Actions package-write credentials, resolves the builtin bundle revision, then publishes `ghcr.io/cherryhq/stella:dev-<commit>` and `ghcr.io/cherryhq/stella-sandbox:dev-<commit>` for linux/amd64. It is manual-only and does not alter stable release tags or automatic PR builds.

## Test

- `mise run format && mise run build && mise run test` passed.
- `mise run test:ci-policy` passed.
- `git diff --check` passed.

## Refs

Refs #1285

## Checklist

- [x] The PR links a GitHub issue.
- [ ] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed. Workflow-only change; no runtime behavior changed.
- [ ] I updated relevant English and Chinese documentation, or no documentation change is needed. The deployment runbook is in the GitOps repository, not the runtime source tree.
- [x] I ran `mise run format && mise run build && mise run test`.
- [x] If this changes agent behavior (tools, prompts, the runner loop): not applicable; this is image publication only.
- [x] If the change touches a surface no eval task exercises: not applicable.
- [x] Any earlier measurement this PR invalidates is marked superseded with its reason, or none exists.
